### PR TITLE
Testnet bootnode ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This command will:
 ### Full node on the test network
 
 Transitioning towards developers, if you'd like to play around with creating Electroneum
-contracts, you almost certainly would like to do that without any real money involved until
+contracts, you almost certainly would like to do that without any real cryptocurrency involved until
 you get the hang of the entire system. In other words, instead of attaching to the main
 network, you want to join the **test** network with your node, which is fully equivalent to
 the main network, but with play-ETN only.
@@ -133,7 +133,7 @@ Specifying the `--testnet` flag, however, will reconfigure your `etn-sc` instanc
 
 *Note: Although there are some internal protective measures to prevent transactions from
 crossing over between the main network and test network, you should make sure to always
-use separate accounts for play-money and real-money. Unless you manually move
+use separate accounts for play-cryptocurrency and real-cryptocurrency. Unless you manually move
 accounts, `etn-sc` will by default correctly separate the two networks and will not make any
 accounts available between them.*
 

--- a/params/bootnodes.go
+++ b/params/bootnodes.go
@@ -28,7 +28,9 @@ var StagenetBootnodes = []string{}
 
 // TestnetBootnodes are the enode URLs of the P2P bootstrap nodes running on
 // the main Electroneum Testnet network.
-var TestnetBootnodes = []string{}
+var TestnetBootnodes = []string{
+	"enode://973089afc9ae8141a47b211cb48979bb1fd2cbf5f24c498b4aab93a7cee5fcb996c7badac0d3b8414608b113bb12b9b997ac5bea35dd7842149a3182e42dfe18@127.0.0.1:30303",
+}
 
 var V5Bootnodes = []string{}
 


### PR DESCRIPTION
Set the official Testnet Bootnode IP address (Seed server). In the future we will most likely add more of these.