### PR TITLE
Handle the token emission when circulating supply is omitted in the genesis.json file

### DIFF
--- a/consensus/istanbul/backend/emission.go
+++ b/consensus/istanbul/backend/emission.go
@@ -36,6 +36,10 @@ type Emission struct {
 }
 
 func newEmission(blockNumber uint64, hash common.Hash, circulatingSupply *big.Int) *Emission {
+	if circulatingSupply == nil {
+		circulatingSupply = big.NewInt(0)
+	}
+
 	emission := &Emission{
 		Number:            blockNumber,
 		Hash:              hash,


### PR DESCRIPTION
If the circulating supply was omitted as a parameter in the genesis.json, this would cause a nil deref/segfault. This commit sets the initial circulating supply as zero in the event of a the missing parameter.