### PR TITLE
consensus: use ceil(2N/3) quorum in committed seal verification

### DIFF
--- a/consensus/istanbul/engine/engine.go
+++ b/consensus/istanbul/engine/engine.go
@@ -2,6 +2,7 @@ package qbftengine
 
 import (
 	"bytes"
+	"math"
 	"math/big"
 	"time"
 
@@ -270,11 +271,10 @@ func (e *Engine) verifyCommittedSeals(chain consensus.ChainHeaderReader, header 
 		return istanbulcommon.ErrInvalidCommittedSeals
 	}
 
-	// IBFT/QBFT finalization requires at least 2F+1 valid committed seals
-	if validSeal < 2*validators.F()+1 {
+	// IBFT/QBFT finalization requires at least 2F+1 valid committed seals requiredSeals := int(math.Ceil(float64(2*validators.Size()) / 3))
+	if validSeal < requiredSeals {
 		return istanbulcommon.ErrInvalidCommittedSeals
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
The existing check used 2*F()+1 which assumes the classical BFT relation N=3F+1, but F() here is derived via ceil(N/3)-1 rather than the standard floor((N-1)/3). This non-standard F() definition means 2F+1 diverges from the intended ceil(2N/3) quorum for validator set sizes that aren't exactly 3F+1. Replace with an explicit ceil(2N/3) to match the core consensus quorum and avoid any ambiguity from the atypical F() derivation.