### PR TITLE
Switch IBFT backlog priority queue from float32 to int64

### DIFF
--- a/consensus/istanbul/core/backlog.go
+++ b/consensus/istanbul/core/backlog.go
@@ -21,9 +21,9 @@ import (
 	"math/big"
 
 	"github.com/electroneum/electroneum-sc/common"
+	"github.com/electroneum/electroneum-sc/common/prque"
 	"github.com/electroneum/electroneum-sc/consensus/istanbul"
 	qbfttypes "github.com/electroneum/electroneum-sc/consensus/istanbul/types"
-	"gopkg.in/karalabe/cookiejar.v2/collections/prque"
 )
 
 const (
@@ -220,7 +220,7 @@ func (c *core) addToBacklog(msg qbfttypes.QBFTMessage) {
 
 	backlog := c.backlogs[src]
 	if backlog == nil {
-		backlog = prque.New()
+		backlog = prque.New(nil)
 		c.backlogs[src] = backlog
 	}
 
@@ -330,13 +330,13 @@ func (c *core) maxBacklogTotal() int {
 	return dynamic
 }
 
-func toPriority(msgCode uint64, view *istanbul.View) float32 {
+func toPriority(msgCode uint64, view *istanbul.View) int64 {
 	if msgCode == qbfttypes.RoundChangeCode {
 		// For msgRoundChange, set the message priority based on its sequence
-		return -float32(view.Sequence.Uint64() * 1000)
+		return -int64(view.Sequence.Uint64() * 1000)
 	}
 	// FIXME: round will be reset as 0 while new sequence
 	// 10 * Round limits the range of message code is from 0 to 9
 	// 1000 * Sequence limits the range of round is from 0 to 99
-	return -float32(view.Sequence.Uint64()*1000 + view.Round.Uint64()*10 + uint64(msgPriority[msgCode]))
+	return -int64(view.Sequence.Uint64()*1000 + view.Round.Uint64()*10 + uint64(msgPriority[msgCode]))
 }

--- a/consensus/istanbul/core/backlog_test.go
+++ b/consensus/istanbul/core/backlog_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 
 	"github.com/electroneum/electroneum-sc/common"
+	"github.com/electroneum/electroneum-sc/common/prque"
 	"github.com/electroneum/electroneum-sc/consensus/istanbul"
 	qbfttypes "github.com/electroneum/electroneum-sc/consensus/istanbul/types"
 	"github.com/electroneum/electroneum-sc/consensus/istanbul/validator"
 	"github.com/electroneum/electroneum-sc/crypto"
 	"github.com/electroneum/electroneum-sc/log"
-	"gopkg.in/karalabe/cookiejar.v2/collections/prque"
 )
 
 // -----------------------------------------------------------------------------
@@ -39,13 +39,15 @@ func newTestCore(valSet istanbul.ValidatorSet, seq, round int64) *core {
 	}
 
 	c := &core{
-		address:    valSet.List()[0].Address(),
-		state:      StateAcceptRequest,
-		logger:     log.New(),
-		valSet:     valSet,
-		backlogs:   make(map[common.Address]*prque.Prque),
-		backlogsMu: new(sync.Mutex),
-		current:    newRoundState(view, valSet, nil, nil, nil, nil, func(common.Hash) bool { return false }),
+		address:           valSet.List()[0].Address(),
+		state:             StateAcceptRequest,
+		logger:            log.New(),
+		valSet:            valSet,
+		backlogs:          make(map[common.Address]*prque.Prque),
+		backlogsMu:        new(sync.Mutex),
+		pendingRequests:   prque.New(nil),
+		pendingRequestsMu: new(sync.Mutex),
+		current:           newRoundState(view, valSet, nil, nil, nil, nil, func(common.Hash) bool { return false }),
 	}
 	return c
 }

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -23,13 +23,13 @@ import (
 	"time"
 
 	"github.com/electroneum/electroneum-sc/common"
+	"github.com/electroneum/electroneum-sc/common/prque"
 	"github.com/electroneum/electroneum-sc/consensus/istanbul"
 	qbfttypes "github.com/electroneum/electroneum-sc/consensus/istanbul/types"
 	"github.com/electroneum/electroneum-sc/core/types"
 	"github.com/electroneum/electroneum-sc/event"
 	"github.com/electroneum/electroneum-sc/log"
 	metrics "github.com/electroneum/electroneum-sc/metrics"
-	"gopkg.in/karalabe/cookiejar.v2/collections/prque"
 )
 
 var (
@@ -50,7 +50,7 @@ func New(backend istanbul.Backend, config *istanbul.Config) istanbul.Core {
 		backend:            backend,
 		backlogs:           make(map[common.Address]*prque.Prque),
 		backlogsMu:         new(sync.Mutex),
-		pendingRequests:    prque.New(),
+		pendingRequests:    prque.New(nil),
 		pendingRequestsMu:  new(sync.Mutex),
 		consensusTimestamp: time.Time{},
 		currentMutex:       new(sync.Mutex),

--- a/consensus/istanbul/core/request.go
+++ b/consensus/istanbul/core/request.go
@@ -73,7 +73,7 @@ func (c *core) storeRequestMsg(request *Request) {
 	c.pendingRequestsMu.Lock()
 	defer c.pendingRequestsMu.Unlock()
 
-	c.pendingRequests.Push(request, float32(-request.Proposal.Number().Int64()))
+	c.pendingRequests.Push(request, -request.Proposal.Number().Int64())
 }
 
 // processPendingRequests is called each time QBFT state is re-initialized


### PR DESCRIPTION
The consensus backlog used the old cookiejar prque (float32 priorities). At large block heights, float32 precision loss causes message type priorities to collide. Switch to common/prque which uses int64, eliminating the precision issue. Also fix the same float32 cast in pending request storage.