### PR TITLE
Cap addresses and per-position topics in log-filter RPC methods

### DIFF
--- a/cmd/etn-sc/config.go
+++ b/cmd/etn-sc/config.go
@@ -175,7 +175,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 
 	// Configure GraphQL if requested
 	if ctx.GlobalIsSet(utils.GraphQLEnabledFlag.Name) {
-		utils.RegisterGraphQLService(stack, backend, cfg.Node)
+		utils.RegisterGraphQLService(stack, backend, cfg.Node, cfg.Eth.RPCLogQueryLimit)
 	}
 	// Add the Ethereum Stats daemon if requested.
 	if cfg.Ethstats.URL != "" {

--- a/cmd/etn-sc/main.go
+++ b/cmd/etn-sc/main.go
@@ -184,6 +184,7 @@ var (
 		utils.RPCGlobalGasCapFlag,
 		utils.RPCGlobalEVMTimeoutFlag,
 		utils.RPCGlobalTxFeeCapFlag,
+		utils.RPCGlobalLogQueryLimitFlag,
 		utils.AllowUnprotectedTxs,
 	}
 

--- a/cmd/etn-sc/usage.go
+++ b/cmd/etn-sc/usage.go
@@ -154,6 +154,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.RPCGlobalGasCapFlag,
 			utils.RPCGlobalEVMTimeoutFlag,
 			utils.RPCGlobalTxFeeCapFlag,
+			utils.RPCGlobalLogQueryLimitFlag,
 			utils.AllowUnprotectedTxs,
 			utils.JSpathFlag,
 			utils.ExecFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -535,6 +535,11 @@ var (
 		Usage: "Sets a cap on transaction fee (in ether) that can be sent via the RPC APIs (0 = no cap)",
 		Value: ethconfig.Defaults.RPCTxFeeCap,
 	}
+	RPCGlobalLogQueryLimitFlag = cli.IntFlag{
+		Name:  "rpc.logquerylimit",
+		Usage: "Sets a cap on the number of addresses and per-position topics accepted by eth_getLogs, eth_newFilter, eth_subscribe(logs), eth_getFilterLogs, and the GraphQL logs resolvers (0 = no cap)",
+		Value: ethconfig.Defaults.RPCLogQueryLimit,
+	}
 	// Authenticated RPC HTTP settings
 	AuthListenFlag = cli.StringFlag{
 		Name:  "authrpc.addr",
@@ -1675,6 +1680,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.GlobalIsSet(RPCGlobalTxFeeCapFlag.Name) {
 		cfg.RPCTxFeeCap = ctx.GlobalFloat64(RPCGlobalTxFeeCapFlag.Name)
 	}
+	if ctx.GlobalIsSet(RPCGlobalLogQueryLimitFlag.Name) {
+		cfg.RPCLogQueryLimit = ctx.GlobalInt(RPCGlobalLogQueryLimitFlag.Name)
+	}
 	if ctx.GlobalIsSet(NoDiscoverFlag.Name) {
 		cfg.EthDiscoveryURLs, cfg.SnapDiscoveryURLs = []string{}, []string{}
 	} else if ctx.GlobalIsSet(DNSDiscoveryFlag.Name) {
@@ -1826,8 +1834,8 @@ func RegisterEthStatsService(stack *node.Node, backend ethapi.Backend, url strin
 }
 
 // RegisterGraphQLService is a utility function to construct a new service and register it against a node.
-func RegisterGraphQLService(stack *node.Node, backend ethapi.Backend, cfg node.Config) {
-	if err := graphql.New(stack, backend, cfg.GraphQLCors, cfg.GraphQLVirtualHosts); err != nil {
+func RegisterGraphQLService(stack *node.Node, backend ethapi.Backend, cfg node.Config, logQueryLimit int) {
+	if err := graphql.New(stack, backend, cfg.GraphQLCors, cfg.GraphQLVirtualHosts, logQueryLimit); err != nil {
 		Fatalf("Failed to register the GraphQL service: %v", err)
 	}
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -349,7 +349,7 @@ func (s *Ethereum) APIs() []rpc.API {
 		}, {
 			Namespace: "eth",
 			Version:   "1.0",
-			Service:   filters.NewPublicFilterAPI(s.APIBackend, false, 5*time.Minute),
+			Service:   filters.NewPublicFilterAPI(s.APIBackend, false, 5*time.Minute, s.config.RPCLogQueryLimit),
 			Public:    true,
 		}, {
 			Namespace: "admin",

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -90,11 +90,12 @@ var Defaults = Config{
 		GasPrice: big.NewInt(params.GWei),
 		Recommit: 3 * time.Second,
 	},
-	TxPool:        core.DefaultTxPoolConfig,
-	RPCGasCap:     50000000,
-	RPCEVMTimeout: 5 * time.Second,
-	GPO:           FullNodeGPO,
-	RPCTxFeeCap:   100000, //  [[ETH($)/ETN($)] / 20(to allow for appreciation, and given that fees will start very low] : correct to jun 2023
+	TxPool:           core.DefaultTxPoolConfig,
+	RPCGasCap:        50000000,
+	RPCEVMTimeout:    5 * time.Second,
+	GPO:              FullNodeGPO,
+	RPCTxFeeCap:      100000, //  [[ETH($)/ETN($)] / 20(to allow for appreciation, and given that fees will start very low] : correct to jun 2023
+	RPCLogQueryLimit: 1000,
 
 	// Quorum
 	Istanbul: *istanbul.DefaultConfig, // Quorum
@@ -206,6 +207,12 @@ type Config struct {
 	// RPCTxFeeCap is the global transaction fee(price * gaslimit) cap for
 	// send-transction variants. The unit is ether.
 	RPCTxFeeCap float64
+
+	// RPCLogQueryLimit caps the number of addresses and per-position topics
+	// accepted by log-filter RPC methods (eth_getLogs, eth_newFilter,
+	// eth_subscribe("logs"), eth_getFilterLogs, and the GraphQL logs resolvers).
+	// 0 disables the cap.
+	RPCLogQueryLimit int
 
 	// Checkpoint is a hardcoded checkpoint which can be nil.
 	Checkpoint *params.TrustedCheckpoint `toml:",omitempty"`

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -58,6 +58,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		RPCGasCap                       uint64
 		RPCEVMTimeout                   time.Duration
 		RPCTxFeeCap                     float64
+		RPCLogQueryLimit                int
 		Checkpoint                      *params.TrustedCheckpoint      `toml:",omitempty"`
 		CheckpointOracle                *params.CheckpointOracleConfig `toml:",omitempty"`
 		OverrideArrowGlacier            *big.Int                       `toml:",omitempty"`
@@ -104,6 +105,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.RPCGasCap = c.RPCGasCap
 	enc.RPCEVMTimeout = c.RPCEVMTimeout
 	enc.RPCTxFeeCap = c.RPCTxFeeCap
+	enc.RPCLogQueryLimit = c.RPCLogQueryLimit
 	enc.Checkpoint = c.Checkpoint
 	enc.CheckpointOracle = c.CheckpointOracle
 	enc.OverrideArrowGlacier = c.OverrideArrowGlacier
@@ -154,6 +156,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		RPCGasCap                       *uint64
 		RPCEVMTimeout                   *time.Duration
 		RPCTxFeeCap                     *float64
+		RPCLogQueryLimit                *int
 		Checkpoint                      *params.TrustedCheckpoint      `toml:",omitempty"`
 		CheckpointOracle                *params.CheckpointOracleConfig `toml:",omitempty"`
 		OverrideArrowGlacier            *big.Int                       `toml:",omitempty"`
@@ -280,6 +283,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.RPCTxFeeCap != nil {
 		c.RPCTxFeeCap = *dec.RPCTxFeeCap
+	}
+	if dec.RPCLogQueryLimit != nil {
+		c.RPCLogQueryLimit = *dec.RPCLogQueryLimit
 	}
 	if dec.Checkpoint != nil {
 		c.Checkpoint = dec.Checkpoint

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -43,27 +43,59 @@ type filter struct {
 	s        *Subscription // associated subscription in event system
 }
 
+// ErrExceedLogQueryLimit is returned when a log-filter request specifies more
+// addresses or per-position topics than the configured cap allows.
+var ErrExceedLogQueryLimit = errors.New("exceed max addresses or topics per query")
+
 // PublicFilterAPI offers support to create and manage filters. This will allow external clients to retrieve various
 // information related to the Ethereum protocol such als blocks, transactions and logs.
 type PublicFilterAPI struct {
-	backend   Backend
-	events    *EventSystem
-	filtersMu sync.Mutex
-	filters   map[rpc.ID]*filter
-	timeout   time.Duration
+	backend       Backend
+	events        *EventSystem
+	filtersMu     sync.Mutex
+	filters       map[rpc.ID]*filter
+	timeout       time.Duration
+	logQueryLimit int
 }
 
 // NewPublicFilterAPI returns a new PublicFilterAPI instance.
-func NewPublicFilterAPI(backend Backend, lightMode bool, timeout time.Duration) *PublicFilterAPI {
+//
+// logQueryLimit caps the number of addresses and per-position topics accepted
+// by log-filter methods. 0 disables the cap.
+func NewPublicFilterAPI(backend Backend, lightMode bool, timeout time.Duration, logQueryLimit int) *PublicFilterAPI {
 	api := &PublicFilterAPI{
-		backend: backend,
-		events:  NewEventSystem(backend, lightMode),
-		filters: make(map[rpc.ID]*filter),
-		timeout: timeout,
+		backend:       backend,
+		events:        NewEventSystem(backend, lightMode),
+		filters:       make(map[rpc.ID]*filter),
+		timeout:       timeout,
+		logQueryLimit: logQueryLimit,
 	}
 	go api.timeoutLoop(timeout)
 
 	return api
+}
+
+// checkLogQueryLimit verifies that a filter criteria does not exceed the
+// configured cap on addresses or per-position topics.
+func (api *PublicFilterAPI) checkLogQueryLimit(crit FilterCriteria) error {
+	return CheckLogQueryLimit(api.logQueryLimit, crit.Addresses, crit.Topics)
+}
+
+// CheckLogQueryLimit compares an address slice and topic matrix against a cap.
+// A cap of 0 disables the check.
+func CheckLogQueryLimit(limit int, addresses []common.Address, topics [][]common.Hash) error {
+	if limit == 0 {
+		return nil
+	}
+	if len(addresses) > limit {
+		return ErrExceedLogQueryLimit
+	}
+	for _, t := range topics {
+		if len(t) > limit {
+			return ErrExceedLogQueryLimit
+		}
+	}
+	return nil
 }
 
 // timeoutLoop runs at the interval set by 'timeout' and deletes filters
@@ -236,6 +268,9 @@ func (api *PublicFilterAPI) NewHeads(ctx context.Context) (*rpc.Subscription, er
 
 // Logs creates a subscription that fires for all new log that match the given filter criteria.
 func (api *PublicFilterAPI) Logs(ctx context.Context, crit FilterCriteria) (*rpc.Subscription, error) {
+	if err := api.checkLogQueryLimit(crit); err != nil {
+		return nil, err
+	}
 	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {
 		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
@@ -288,6 +323,9 @@ type FilterCriteria electroneum.FilterQuery
 //
 // https://eth.wiki/json-rpc/API#eth_newfilter
 func (api *PublicFilterAPI) NewFilter(crit FilterCriteria) (rpc.ID, error) {
+	if err := api.checkLogQueryLimit(crit); err != nil {
+		return "", err
+	}
 	logs := make(chan []*types.Log)
 	logsSub, err := api.events.SubscribeLogs(electroneum.FilterQuery(crit), logs)
 	if err != nil {
@@ -323,6 +361,9 @@ func (api *PublicFilterAPI) NewFilter(crit FilterCriteria) (rpc.ID, error) {
 //
 // https://eth.wiki/json-rpc/API#eth_getlogs
 func (api *PublicFilterAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([]*types.Log, error) {
+	if err := api.checkLogQueryLimit(crit); err != nil {
+		return nil, err
+	}
 	var filter *Filter
 	if crit.BlockHash != nil {
 		// Block filter requested, construct a single-shot filter
@@ -376,6 +417,9 @@ func (api *PublicFilterAPI) GetFilterLogs(ctx context.Context, id rpc.ID) ([]*ty
 
 	if !found || f.typ != LogsSubscription {
 		return nil, fmt.Errorf("filter not found")
+	}
+	if err := api.checkLogQueryLimit(f.crit); err != nil {
+		return nil, err
 	}
 
 	var filter *Filter

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -167,7 +167,7 @@ func TestBlockSubscription(t *testing.T) {
 	var (
 		db          = rawdb.NewMemoryDatabase()
 		backend     = &testBackend{db: db}
-		api         = NewPublicFilterAPI(backend, false, deadline)
+		api         = NewPublicFilterAPI(backend, false, deadline, 0)
 		genesis     = (&core.Genesis{BaseFee: big.NewInt(params.InitialBaseFee)}).MustCommit(db)
 		chain, _    = core.GenerateChain(params.TestChainConfig, genesis, ethash.NewFaker(), db, 10, func(i int, gen *core.BlockGen) {})
 		chainEvents = []core.ChainEvent{}
@@ -219,7 +219,7 @@ func TestPendingTxFilter(t *testing.T) {
 	var (
 		db      = rawdb.NewMemoryDatabase()
 		backend = &testBackend{db: db}
-		api     = NewPublicFilterAPI(backend, false, deadline)
+		api     = NewPublicFilterAPI(backend, false, deadline, 0)
 
 		transactions = []*types.Transaction{
 			types.NewTransaction(0, common.HexToAddress("0xb794f5ea0ba39494ce83a213fffba74279579268"), new(big.Int), 0, new(big.Int), nil),
@@ -274,7 +274,7 @@ func TestLogFilterCreation(t *testing.T) {
 	var (
 		db      = rawdb.NewMemoryDatabase()
 		backend = &testBackend{db: db}
-		api     = NewPublicFilterAPI(backend, false, deadline)
+		api     = NewPublicFilterAPI(backend, false, deadline, 0)
 
 		testCases = []struct {
 			crit    FilterCriteria
@@ -321,7 +321,7 @@ func TestInvalidLogFilterCreation(t *testing.T) {
 	var (
 		db      = rawdb.NewMemoryDatabase()
 		backend = &testBackend{db: db}
-		api     = NewPublicFilterAPI(backend, false, deadline)
+		api     = NewPublicFilterAPI(backend, false, deadline, 0)
 	)
 
 	// different situations where log filter creation should fail.
@@ -343,7 +343,7 @@ func TestInvalidGetLogsRequest(t *testing.T) {
 	var (
 		db        = rawdb.NewMemoryDatabase()
 		backend   = &testBackend{db: db}
-		api       = NewPublicFilterAPI(backend, false, deadline)
+		api       = NewPublicFilterAPI(backend, false, deadline, 0)
 		blockHash = common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
 	)
 
@@ -368,7 +368,7 @@ func TestLogFilter(t *testing.T) {
 	var (
 		db      = rawdb.NewMemoryDatabase()
 		backend = &testBackend{db: db}
-		api     = NewPublicFilterAPI(backend, false, deadline)
+		api     = NewPublicFilterAPI(backend, false, deadline, 0)
 
 		firstAddr      = common.HexToAddress("0x1111111111111111111111111111111111111111")
 		secondAddr     = common.HexToAddress("0x2222222222222222222222222222222222222222")
@@ -482,7 +482,7 @@ func TestPendingLogsSubscription(t *testing.T) {
 	var (
 		db      = rawdb.NewMemoryDatabase()
 		backend = &testBackend{db: db}
-		api     = NewPublicFilterAPI(backend, false, deadline)
+		api     = NewPublicFilterAPI(backend, false, deadline, 0)
 
 		firstAddr      = common.HexToAddress("0x1111111111111111111111111111111111111111")
 		secondAddr     = common.HexToAddress("0x2222222222222222222222222222222222222222")
@@ -666,7 +666,7 @@ func TestPendingTxFilterDeadlock(t *testing.T) {
 	var (
 		db      = rawdb.NewMemoryDatabase()
 		backend = &testBackend{db: db}
-		api     = NewPublicFilterAPI(backend, false, timeout)
+		api     = NewPublicFilterAPI(backend, false, timeout, 0)
 		done    = make(chan struct{})
 	)
 

--- a/eth/filters/log_query_limit_test.go
+++ b/eth/filters/log_query_limit_test.go
@@ -1,0 +1,174 @@
+// Copyright 2026 The electroneum-sc Authors
+// This file is part of the electroneum-sc library.
+//
+// The electroneum-sc library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The electroneum-sc library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the electroneum-sc library. If not, see <http://www.gnu.org/licenses/>.
+
+package filters
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/electroneum/electroneum-sc/common"
+	"github.com/electroneum/electroneum-sc/core/rawdb"
+)
+
+// makeAddresses returns n distinct synthetic addresses.
+func makeAddresses(n int) []common.Address {
+	out := make([]common.Address, n)
+	for i := 0; i < n; i++ {
+		out[i] = common.BytesToAddress(big.NewInt(int64(i + 1)).Bytes())
+	}
+	return out
+}
+
+// makeTopics returns a single-position topic list with n entries.
+func makeTopics(n int) [][]common.Hash {
+	row := make([]common.Hash, n)
+	for i := 0; i < n; i++ {
+		row[i] = common.BytesToHash(big.NewInt(int64(i + 1)).Bytes())
+	}
+	return [][]common.Hash{row}
+}
+
+// newAPIWithLimit builds a PublicFilterAPI backed by an empty in-memory
+// database with the supplied log-query cap.
+func newAPIWithLimit(limit int) *PublicFilterAPI {
+	backend := &testBackend{db: rawdb.NewMemoryDatabase()}
+	return NewPublicFilterAPI(backend, false, deadline, limit)
+}
+
+func TestCheckLogQueryLimit(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		limit     int
+		addresses int
+		topics    int
+		wantErr   bool
+	}{
+		{"disabled cap accepts huge address list", 0, 100_000, 0, false},
+		{"under cap is accepted", 10, 10, 10, false},
+		{"address overflow is rejected", 10, 11, 0, true},
+		{"topic overflow is rejected", 10, 0, 11, true},
+		{"both within cap is accepted", 1000, 1000, 1000, false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := CheckLogQueryLimit(tc.limit, makeAddresses(tc.addresses), makeTopics(tc.topics))
+			if tc.wantErr && !errors.Is(err, ErrExceedLogQueryLimit) {
+				t.Fatalf("expected ErrExceedLogQueryLimit, got %v", err)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected nil, got %v", err)
+			}
+		})
+	}
+}
+
+func TestGetLogsRejectsOversizedAddresses(t *testing.T) {
+	t.Parallel()
+
+	api := newAPIWithLimit(10)
+	crit := FilterCriteria{
+		FromBlock: big.NewInt(0),
+		ToBlock:   big.NewInt(1),
+		Addresses: makeAddresses(11),
+	}
+	if _, err := api.GetLogs(context.Background(), crit); !errors.Is(err, ErrExceedLogQueryLimit) {
+		t.Fatalf("GetLogs: expected ErrExceedLogQueryLimit, got %v", err)
+	}
+}
+
+func TestGetLogsRejectsOversizedTopics(t *testing.T) {
+	t.Parallel()
+
+	api := newAPIWithLimit(10)
+	crit := FilterCriteria{
+		FromBlock: big.NewInt(0),
+		ToBlock:   big.NewInt(1),
+		Topics:    makeTopics(11),
+	}
+	if _, err := api.GetLogs(context.Background(), crit); !errors.Is(err, ErrExceedLogQueryLimit) {
+		t.Fatalf("GetLogs: expected ErrExceedLogQueryLimit for oversized topics, got %v", err)
+	}
+}
+
+func TestNewFilterRejectsOversizedAddresses(t *testing.T) {
+	t.Parallel()
+
+	api := newAPIWithLimit(10)
+	crit := FilterCriteria{
+		FromBlock: big.NewInt(0),
+		ToBlock:   big.NewInt(1),
+		Addresses: makeAddresses(11),
+	}
+	if _, err := api.NewFilter(crit); !errors.Is(err, ErrExceedLogQueryLimit) {
+		t.Fatalf("NewFilter: expected ErrExceedLogQueryLimit, got %v", err)
+	}
+}
+
+func TestLogsSubscribeRejectsOversizedAddresses(t *testing.T) {
+	t.Parallel()
+
+	api := newAPIWithLimit(10)
+	crit := FilterCriteria{
+		FromBlock: big.NewInt(0),
+		ToBlock:   big.NewInt(1),
+		Addresses: makeAddresses(11),
+	}
+	// No notifier in context: the limit check runs first and must reject
+	// before reaching the unsupported-notifier path.
+	if _, err := api.Logs(context.Background(), crit); !errors.Is(err, ErrExceedLogQueryLimit) {
+		t.Fatalf("Logs: expected ErrExceedLogQueryLimit, got %v", err)
+	}
+}
+
+func TestZeroLimitDisablesCap(t *testing.T) {
+	t.Parallel()
+
+	api := newAPIWithLimit(0)
+	crit := FilterCriteria{
+		FromBlock: big.NewInt(0),
+		ToBlock:   big.NewInt(1),
+		Addresses: makeAddresses(50_000),
+	}
+	// We don't care whether the query succeeds — only that the limit check
+	// does not reject it.
+	if _, err := api.GetLogs(context.Background(), crit); errors.Is(err, ErrExceedLogQueryLimit) {
+		t.Fatalf("GetLogs: unexpected ErrExceedLogQueryLimit with zero (disabled) cap")
+	}
+}
+
+func TestUnderLimitIsAccepted(t *testing.T) {
+	t.Parallel()
+
+	api := newAPIWithLimit(1000)
+	crit := FilterCriteria{
+		FromBlock: big.NewInt(0),
+		ToBlock:   big.NewInt(1),
+		Addresses: makeAddresses(1000),
+		Topics:    makeTopics(1000),
+	}
+	if _, err := api.GetLogs(context.Background(), crit); errors.Is(err, ErrExceedLogQueryLimit) {
+		t.Fatalf("GetLogs: unexpected ErrExceedLogQueryLimit at exact cap")
+	}
+	if _, err := api.NewFilter(crit); errors.Is(err, ErrExceedLogQueryLimit) {
+		t.Fatalf("NewFilter: unexpected ErrExceedLogQueryLimit at exact cap")
+	}
+}

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -183,11 +183,12 @@ func (at *AccessTuple) StorageKeys(ctx context.Context) []common.Hash {
 // Transaction represents an Ethereum transaction.
 // backend and hash are mandatory; all others will be fetched when required.
 type Transaction struct {
-	backend ethapi.Backend
-	hash    common.Hash
-	tx      *types.Transaction
-	block   *Block
-	index   uint64
+	backend       ethapi.Backend
+	hash          common.Hash
+	tx            *types.Transaction
+	block         *Block
+	index         uint64
+	logQueryLimit int
 }
 
 // resolve returns the internal transaction object, fetching it if needed.
@@ -199,8 +200,9 @@ func (t *Transaction) resolve(ctx context.Context) (*types.Transaction, error) {
 			t.tx = tx
 			blockNrOrHash := rpc.BlockNumberOrHashWithHash(blockHash, false)
 			t.block = &Block{
-				backend:      t.backend,
-				numberOrHash: &blockNrOrHash,
+				backend:       t.backend,
+				numberOrHash:  &blockNrOrHash,
+				logQueryLimit: t.logQueryLimit,
 			}
 			t.index = index
 			return t.tx, nil
@@ -555,12 +557,13 @@ type BlockType int
 // backend, and numberOrHash are mandatory. All other fields are lazily fetched
 // when required.
 type Block struct {
-	backend      ethapi.Backend
-	numberOrHash *rpc.BlockNumberOrHash
-	hash         common.Hash
-	header       *types.Header
-	block        *types.Block
-	receipts     []*types.Receipt
+	backend       ethapi.Backend
+	numberOrHash  *rpc.BlockNumberOrHash
+	hash          common.Hash
+	header        *types.Header
+	block         *types.Block
+	receipts      []*types.Receipt
+	logQueryLimit int
 }
 
 // resolve returns the internal Block object representing this block, fetching
@@ -695,9 +698,10 @@ func (b *Block) Parent(ctx context.Context) (*Block, error) {
 	}
 	num := rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(b.header.Number.Uint64() - 1))
 	return &Block{
-		backend:      b.backend,
-		numberOrHash: &num,
-		hash:         b.header.ParentHash,
+		backend:       b.backend,
+		numberOrHash:  &num,
+		hash:          b.header.ParentHash,
+		logQueryLimit: b.logQueryLimit,
 	}, nil
 }
 
@@ -783,9 +787,10 @@ func (b *Block) Ommers(ctx context.Context) (*[]*Block, error) {
 	for _, uncle := range block.Uncles() {
 		blockNumberOrHash := rpc.BlockNumberOrHashWithHash(uncle.Hash(), false)
 		ret = append(ret, &Block{
-			backend:      b.backend,
-			numberOrHash: &blockNumberOrHash,
-			header:       uncle,
+			backend:       b.backend,
+			numberOrHash:  &blockNumberOrHash,
+			header:        uncle,
+			logQueryLimit: b.logQueryLimit,
 		})
 	}
 	return &ret, nil
@@ -892,11 +897,12 @@ func (b *Block) Transactions(ctx context.Context) (*[]*Transaction, error) {
 	ret := make([]*Transaction, 0, len(block.Transactions()))
 	for i, tx := range block.Transactions() {
 		ret = append(ret, &Transaction{
-			backend: b.backend,
-			hash:    tx.Hash(),
-			tx:      tx,
-			block:   b,
-			index:   uint64(i),
+			backend:       b.backend,
+			hash:          tx.Hash(),
+			tx:            tx,
+			block:         b,
+			index:         uint64(i),
+			logQueryLimit: b.logQueryLimit,
 		})
 	}
 	return &ret, nil
@@ -913,11 +919,12 @@ func (b *Block) TransactionAt(ctx context.Context, args struct{ Index int32 }) (
 	}
 	tx := txs[args.Index]
 	return &Transaction{
-		backend: b.backend,
-		hash:    tx.Hash(),
-		tx:      tx,
-		block:   b,
-		index:   uint64(args.Index),
+		backend:       b.backend,
+		hash:          tx.Hash(),
+		tx:            tx,
+		block:         b,
+		index:         uint64(args.Index),
+		logQueryLimit: b.logQueryLimit,
 	}, nil
 }
 
@@ -933,9 +940,10 @@ func (b *Block) OmmerAt(ctx context.Context, args struct{ Index int32 }) (*Block
 	uncle := uncles[args.Index]
 	blockNumberOrHash := rpc.BlockNumberOrHashWithHash(uncle.Hash(), false)
 	return &Block{
-		backend:      b.backend,
-		numberOrHash: &blockNumberOrHash,
-		header:       uncle,
+		backend:       b.backend,
+		numberOrHash:  &blockNumberOrHash,
+		header:        uncle,
+		logQueryLimit: b.logQueryLimit,
 	}, nil
 }
 
@@ -984,6 +992,9 @@ func (b *Block) Logs(ctx context.Context, args struct{ Filter BlockFilterCriteri
 	var topics [][]common.Hash
 	if args.Filter.Topics != nil {
 		topics = *args.Filter.Topics
+	}
+	if err := filters.CheckLogQueryLimit(b.logQueryLimit, addresses, topics); err != nil {
+		return nil, err
 	}
 	hash := b.hash
 	if hash == (common.Hash{}) {
@@ -1087,7 +1098,8 @@ func (b *Block) EstimateGas(ctx context.Context, args struct {
 }
 
 type Pending struct {
-	backend ethapi.Backend
+	backend       ethapi.Backend
+	logQueryLimit int
 }
 
 func (p *Pending) TransactionCount(ctx context.Context) (int32, error) {
@@ -1103,10 +1115,11 @@ func (p *Pending) Transactions(ctx context.Context) (*[]*Transaction, error) {
 	ret := make([]*Transaction, 0, len(txs))
 	for i, tx := range txs {
 		ret = append(ret, &Transaction{
-			backend: p.backend,
-			hash:    tx.Hash(),
-			tx:      tx,
-			index:   uint64(i),
+			backend:       p.backend,
+			hash:          tx.Hash(),
+			tx:            tx,
+			index:         uint64(i),
+			logQueryLimit: p.logQueryLimit,
 		})
 	}
 	return &ret, nil
@@ -1153,7 +1166,8 @@ func (p *Pending) EstimateGas(ctx context.Context, args struct {
 
 // Resolver is the top-level object in the GraphQL hierarchy.
 type Resolver struct {
-	backend ethapi.Backend
+	backend       ethapi.Backend
+	logQueryLimit int
 }
 
 func (r *Resolver) Block(ctx context.Context, args struct {
@@ -1168,20 +1182,23 @@ func (r *Resolver) Block(ctx context.Context, args struct {
 		number := rpc.BlockNumber(*args.Number)
 		numberOrHash := rpc.BlockNumberOrHashWithNumber(number)
 		block = &Block{
-			backend:      r.backend,
-			numberOrHash: &numberOrHash,
+			backend:       r.backend,
+			numberOrHash:  &numberOrHash,
+			logQueryLimit: r.logQueryLimit,
 		}
 	} else if args.Hash != nil {
 		numberOrHash := rpc.BlockNumberOrHashWithHash(*args.Hash, false)
 		block = &Block{
-			backend:      r.backend,
-			numberOrHash: &numberOrHash,
+			backend:       r.backend,
+			numberOrHash:  &numberOrHash,
+			logQueryLimit: r.logQueryLimit,
 		}
 	} else {
 		numberOrHash := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 		block = &Block{
-			backend:      r.backend,
-			numberOrHash: &numberOrHash,
+			backend:       r.backend,
+			numberOrHash:  &numberOrHash,
+			logQueryLimit: r.logQueryLimit,
 		}
 	}
 	// Resolve the header, return nil if it doesn't exist.
@@ -1215,8 +1232,9 @@ func (r *Resolver) Blocks(ctx context.Context, args struct {
 	for i := from; i <= to; i++ {
 		numberOrHash := rpc.BlockNumberOrHashWithNumber(i)
 		block := &Block{
-			backend:      r.backend,
-			numberOrHash: &numberOrHash,
+			backend:       r.backend,
+			numberOrHash:  &numberOrHash,
+			logQueryLimit: r.logQueryLimit,
 		}
 		// Resolve the header to check for existence.
 		// Note we don't resolve block directly here since it will require an
@@ -1234,13 +1252,14 @@ func (r *Resolver) Blocks(ctx context.Context, args struct {
 }
 
 func (r *Resolver) Pending(ctx context.Context) *Pending {
-	return &Pending{r.backend}
+	return &Pending{backend: r.backend, logQueryLimit: r.logQueryLimit}
 }
 
 func (r *Resolver) Transaction(ctx context.Context, args struct{ Hash common.Hash }) (*Transaction, error) {
 	tx := &Transaction{
-		backend: r.backend,
-		hash:    args.Hash,
+		backend:       r.backend,
+		hash:          args.Hash,
+		logQueryLimit: r.logQueryLimit,
 	}
 	// Resolve the transaction; if it doesn't exist, return nil.
 	t, err := tx.resolve(ctx)
@@ -1298,6 +1317,9 @@ func (r *Resolver) Logs(ctx context.Context, args struct{ Filter FilterCriteria 
 	var topics [][]common.Hash
 	if args.Filter.Topics != nil {
 		topics = *args.Filter.Topics
+	}
+	if err := filters.CheckLogQueryLimit(r.logQueryLimit, addresses, topics); err != nil {
+		return nil, err
 	}
 	// Construct the range filter
 	filter := filters.NewRangeFilter(filters.Backend(r.backend), begin, end, addresses, topics)

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -50,7 +50,7 @@ func TestBuildSchema(t *testing.T) {
 	}
 	defer stack.Close()
 	// Make sure the schema can be parsed and matched up to the object model.
-	if err := newHandler(stack, nil, []string{}, []string{}); err != nil {
+	if err := newHandler(stack, nil, []string{}, []string{}, 0); err != nil {
 		t.Errorf("Could not construct GraphQL handler: %v", err)
 	}
 }
@@ -263,7 +263,7 @@ func createGQLService(t *testing.T, stack *node.Node) {
 		t.Fatalf("could not create import blocks: %v", err)
 	}
 	// create gql service
-	err = New(stack, ethBackend.APIBackend, []string{}, []string{})
+	err = New(stack, ethBackend.APIBackend, []string{}, []string{}, 0)
 	if err != nil {
 		t.Fatalf("could not create graphql service: %v", err)
 	}
@@ -348,7 +348,7 @@ func createGQLServiceWithTransactions(t *testing.T, stack *node.Node) {
 		t.Fatalf("could not create import blocks: %v", err)
 	}
 	// create gql service
-	err = New(stack, ethBackend.APIBackend, []string{}, []string{})
+	err = New(stack, ethBackend.APIBackend, []string{}, []string{}, 0)
 	if err != nil {
 		t.Fatalf("could not create graphql service: %v", err)
 	}

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -55,18 +55,21 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // New constructs a new GraphQL service instance.
-func New(stack *node.Node, backend ethapi.Backend, cors, vhosts []string) error {
+//
+// logQueryLimit caps the number of addresses and per-position topics accepted
+// by the `logs` resolvers. 0 disables the cap.
+func New(stack *node.Node, backend ethapi.Backend, cors, vhosts []string, logQueryLimit int) error {
 	if backend == nil {
 		panic("missing backend")
 	}
 	// check if http server with given endpoint exists and enable graphQL on it
-	return newHandler(stack, backend, cors, vhosts)
+	return newHandler(stack, backend, cors, vhosts, logQueryLimit)
 }
 
 // newHandler returns a new `http.Handler` that will answer GraphQL queries.
 // It additionally exports an interactive query browser on the / endpoint.
-func newHandler(stack *node.Node, backend ethapi.Backend, cors, vhosts []string) error {
-	q := Resolver{backend}
+func newHandler(stack *node.Node, backend ethapi.Backend, cors, vhosts []string, logQueryLimit int) error {
+	q := Resolver{backend: backend, logQueryLimit: logQueryLimit}
 
 	s, err := graphql.ParseSchema(schema, &q)
 	if err != nil {

--- a/les/client.go
+++ b/les/client.go
@@ -298,7 +298,7 @@ func (s *LightEthereum) APIs() []rpc.API {
 		}, {
 			Namespace: "eth",
 			Version:   "1.0",
-			Service:   filters.NewPublicFilterAPI(s.ApiBackend, true, 5*time.Minute),
+			Service:   filters.NewPublicFilterAPI(s.ApiBackend, true, 5*time.Minute, s.config.RPCLogQueryLimit),
 			Public:    true,
 		}, {
 			Namespace: "net",


### PR DESCRIPTION
Adds RPCLogQueryLimit (default 1000, --rpc.logquerylimit, 0 disables) and enforces it on eth_getLogs, eth_newFilter, eth_subscribe(logs), eth_getFilterLogs, and the GraphQL Block.logs / Resolver.logs resolvers to prevent the unbounded-Addresses DoS where ~200k addresses pass under the 10MB JSON-RPC body limit and stall the node in bloomFilter() / filterLogs(). Upstream geth (PR #32327) added the same flag but only guards eth_getLogs; this change covers the remaining paths it missed.