### PR TITLE
Deep-copy CirculatingSupply in Emission.copy()

### DIFF
--- a/consensus/istanbul/backend/emission.go
+++ b/consensus/istanbul/backend/emission.go
@@ -74,9 +74,11 @@ func (e *Emission) store(db ethdb.Database) error {
 // copy creates a deep copy of the emission snapshot
 func (e *Emission) copy() *Emission {
 	cpy := &Emission{
-		Number:            e.Number,
-		Hash:              e.Hash,
-		CirculatingSupply: e.CirculatingSupply,
+		Number: e.Number,
+		Hash:   e.Hash,
+	}
+	if e.CirculatingSupply != nil {
+		cpy.CirculatingSupply = new(big.Int).Set(e.CirculatingSupply)
 	}
 
 	return cpy


### PR DESCRIPTION
Emission.copy() is documented as a deep copy but copied the CirculatingSupply *big.Int by pointer, so the copy and original shared the same underlying value. This is benign today because the only mutating caller reassigns the field to a freshly allocated big.Int rather than mutating in place, but any future in-place mutation would corrupt the cached original. Allocate a fresh big.Int via new(big.Int).Set, guarding against a nil source.