### PR TITLE
eth/protocols/eth: return no headers for zero-amount GetBlockHeaders queries

### DIFF
--- a/accounts/abi/argument.go
+++ b/accounts/abi/argument.go
@@ -111,7 +111,7 @@ func (arguments Arguments) UnpackIntoMap(v map[string]interface{}, data []byte) 
 // Copy performs the operation go format -> provided struct.
 func (arguments Arguments) Copy(v interface{}, values []interface{}) error {
 	// make sure the passed value is arguments pointer
-	if reflect.Ptr != reflect.ValueOf(v).Kind() {
+	if reflect.Pointer != reflect.ValueOf(v).Kind() {
 		return fmt.Errorf("abi: Unpack(non-pointer %T)", v)
 	}
 	if len(values) == 0 {

--- a/accounts/abi/pack.go
+++ b/accounts/abi/pack.go
@@ -77,7 +77,7 @@ func packNum(value reflect.Value) []byte {
 		return math.U256Bytes(new(big.Int).SetUint64(value.Uint()))
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return math.U256Bytes(big.NewInt(value.Int()))
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return math.U256Bytes(new(big.Int).Set(value.Interface().(*big.Int)))
 	default:
 		panic("abi: fatal error")

--- a/accounts/abi/reflect.go
+++ b/accounts/abi/reflect.go
@@ -53,7 +53,7 @@ func ConvertType(in interface{}, proto interface{}) interface{} {
 // indirect recursively dereferences the value until it either gets the value
 // or finds a big.Int
 func indirect(v reflect.Value) reflect.Value {
-	if v.Kind() == reflect.Ptr && v.Elem().Type() != reflect.TypeOf(big.Int{}) {
+	if v.Kind() == reflect.Pointer && v.Elem().Type() != reflect.TypeOf(big.Int{}) {
 		return indirect(v.Elem())
 	}
 	return v
@@ -104,7 +104,7 @@ func set(dst, src reflect.Value) error {
 	switch {
 	case dstType.Kind() == reflect.Interface && dst.Elem().IsValid():
 		return set(dst.Elem(), src)
-	case dstType.Kind() == reflect.Ptr && dstType.Elem() != reflect.TypeOf(big.Int{}):
+	case dstType.Kind() == reflect.Pointer && dstType.Elem() != reflect.TypeOf(big.Int{}):
 		return set(dst.Elem(), src)
 	case srcType.AssignableTo(dstType) && dst.CanSet():
 		dst.Set(src)
@@ -138,7 +138,7 @@ func setSlice(dst, src reflect.Value) error {
 }
 
 func setArray(dst, src reflect.Value) error {
-	if src.Kind() == reflect.Ptr {
+	if src.Kind() == reflect.Pointer {
 		return set(dst, indirect(src))
 	}
 	array := reflect.New(dst.Type()).Elem()

--- a/crypto/blake2b/blake2b.go
+++ b/crypto/blake2b/blake2b.go
@@ -302,7 +302,7 @@ func appendUint64(b []byte, x uint64) []byte {
 	return append(b, a[:]...)
 }
 
-//nolint:unused,deadcode
+//nolint:unused
 func appendUint32(b []byte, x uint32) []byte {
 	var a [4]byte
 	binary.BigEndian.PutUint32(a[:], x)
@@ -314,7 +314,7 @@ func consumeUint64(b []byte) ([]byte, uint64) {
 	return b[8:], x
 }
 
-//nolint:unused,deadcode
+//nolint:unused
 func consumeUint32(b []byte) ([]byte, uint32) {
 	x := binary.BigEndian.Uint32(b)
 	return b[4:], x

--- a/crypto/blake2b/blake2b_generic.go
+++ b/crypto/blake2b/blake2b_generic.go
@@ -25,7 +25,7 @@ var precomputed = [10][16]byte{
 	{10, 8, 7, 1, 2, 4, 6, 5, 15, 9, 3, 13, 11, 14, 12, 0},
 }
 
-// nolint:unused,deadcode
+// nolint:unused
 func hashBlocksGeneric(h *[8]uint64, c *[2]uint64, flag uint64, blocks []byte) {
 	var m [16]uint64
 	c0, c1 := c[0], c[1]

--- a/crypto/bn256/cloudflare/gfp_decl.go
+++ b/crypto/bn256/cloudflare/gfp_decl.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/sys/cpu"
 )
 
-//nolint:varcheck,unused,deadcode
+//nolint:unused
 var hasBMI2 = cpu.X86.HasBMI2
 
 //go:noescape

--- a/eth/filters/log_query_limit_test.go
+++ b/eth/filters/log_query_limit_test.go
@@ -68,7 +68,6 @@ func TestCheckLogQueryLimit(t *testing.T) {
 		{"both within cap is accepted", 1000, 1000, 1000, false},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			err := CheckLogQueryLimit(tc.limit, makeAddresses(tc.addresses), makeTopics(tc.topics))
 			if tc.wantErr && !errors.Is(err, ErrExceedLogQueryLimit) {

--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -255,6 +255,16 @@ func testGetBlockHeaders(t *testing.T, protocol uint) {
 			&GetBlockHeadersPacket{Origin: HashOrNumber{Number: backend.chain.CurrentBlock().NumberU64() + 1}, Amount: 1},
 			[]common.Hash{},
 		},
+		// Check that zero-amount queries return no headers in both number and
+		// hash origin modes. In hash mode, count-1 would otherwise underflow to
+		// a huge uint64 and be clamped into serving the whole canonical prefix.
+		{
+			&GetBlockHeadersPacket{Origin: HashOrNumber{Number: limit / 2}, Amount: 0},
+			[]common.Hash{},
+		}, {
+			&GetBlockHeadersPacket{Origin: HashOrNumber{Hash: backend.chain.GetBlockByNumber(limit / 2).Hash()}, Amount: 0},
+			[]common.Hash{},
+		},
 	}
 	// Run each of the tests and verify the results against the chain
 	for i, tt := range tests {

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -141,6 +141,13 @@ func serviceNonContiguousBlockHeaderQuery(chain *core.BlockChain, query *GetBloc
 
 func serviceContiguousBlockHeaderQuery(chain *core.BlockChain, query *GetBlockHeadersPacket) []rlp.RawValue {
 	count := query.Amount
+	if count == 0 {
+		// A zero-amount query returns no headers. Guard against the
+		// underflow of count-1 in hash mode, which would otherwise wrap to
+		// a huge uint64 and be clamped into serving the whole canonical
+		// prefix instead of an empty response.
+		return nil
+	}
 	if count > maxHeadersServe {
 		count = maxHeadersServe
 	}

--- a/log/format.go
+++ b/log/format.go
@@ -289,7 +289,7 @@ func JSONFormatEx(pretty, lineSeparated bool) Format {
 func formatShared(value interface{}) (result interface{}) {
 	defer func() {
 		if err := recover(); err != nil {
-			if v := reflect.ValueOf(value); v.Kind() == reflect.Ptr && v.IsNil() {
+			if v := reflect.ValueOf(value); v.Kind() == reflect.Pointer && v.IsNil() {
 				result = "nil"
 			} else {
 				panic(err)

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -159,7 +159,7 @@ func makeDecoder(typ reflect.Type, tags rlpstruct.Tags) (dec decoder, err error)
 		return decodeBigInt, nil
 	case typ.AssignableTo(bigInt):
 		return decodeBigIntNoPtr, nil
-	case kind == reflect.Ptr:
+	case kind == reflect.Pointer:
 		return makePtrDecoder(typ, tags)
 	case reflect.PointerTo(typ).Implements(decoderInterface):
 		return decodeDecoder, nil
@@ -872,7 +872,7 @@ func (s *Stream) Decode(val interface{}) error {
 	}
 	rval := reflect.ValueOf(val)
 	rtyp := rval.Type()
-	if rtyp.Kind() != reflect.Ptr {
+	if rtyp.Kind() != reflect.Pointer {
 		return errNoPointer
 	}
 	if rval.IsNil() {

--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -141,7 +141,7 @@ func makeWriter(typ reflect.Type, ts rlpstruct.Tags) (writer, error) {
 		return writeBigIntPtr, nil
 	case typ.AssignableTo(bigInt):
 		return writeBigIntNoPtr, nil
-	case kind == reflect.Ptr:
+	case kind == reflect.Pointer:
 		return makePtrWriter(typ, ts)
 	case reflect.PointerTo(typ).Implements(encoderInterface):
 		return makeEncoderWriter(typ), nil

--- a/rlp/internal/rlpstruct/rlpstruct.go
+++ b/rlp/internal/rlpstruct/rlpstruct.go
@@ -156,7 +156,7 @@ func parseTag(field Field, lastPublic int) (Tags, error) {
 			ts.Ignored = true
 		case "nil", "nilString", "nilList":
 			ts.NilOK = true
-			if field.Type.Kind != reflect.Ptr {
+			if field.Type.Kind != reflect.Pointer {
 				return ts, TagError{Field: name, Tag: t, Err: "field is not a pointer"}
 			}
 			switch t {

--- a/rlp/rlpgen/types.go
+++ b/rlp/rlpgen/types.go
@@ -47,7 +47,7 @@ func typeReflectKind(typ types.Type) reflect.Kind {
 	case *types.Map:
 		return reflect.Map
 	case *types.Pointer:
-		return reflect.Ptr
+		return reflect.Pointer
 	case *types.Signature:
 		return reflect.Func
 	case *types.Slice:

--- a/rlp/typecache.go
+++ b/rlp/typecache.go
@@ -205,7 +205,7 @@ func rtypeToStructType(typ reflect.Type, rec map[reflect.Type]*rlpstruct.Type) *
 		IsDecoder: typ.Implements(decoderInterface),
 	}
 	rec[typ] = t
-	if k == reflect.Array || k == reflect.Slice || k == reflect.Ptr {
+	if k == reflect.Array || k == reflect.Slice || k == reflect.Pointer {
 		t.Elem = rtypeToStructType(typ.Elem(), rec)
 	}
 	return t

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -290,7 +290,7 @@ func (c *Client) Call(result interface{}, method string, args ...interface{}) er
 // The result must be a pointer so that package json can unmarshal into it. You
 // can also pass nil, in which case the result is ignored.
 func (c *Client) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
-	if result != nil && reflect.TypeOf(result).Kind() != reflect.Ptr {
+	if result != nil && reflect.TypeOf(result).Kind() != reflect.Pointer {
 		return fmt.Errorf("call result parameter must be pointer or nil interface: %v", result)
 	}
 	msg, err := c.newMessage(method, args...)

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -304,7 +304,7 @@ func parsePositionalArguments(rawArgs json.RawMessage, types []reflect.Type) ([]
 	}
 	// Set any missing args to nil.
 	for i := len(args); i < len(types); i++ {
-		if types[i].Kind() != reflect.Ptr {
+		if types[i].Kind() != reflect.Pointer {
 			return nil, fmt.Errorf("missing value for required argument %d", i)
 		}
 		args = append(args, reflect.Zero(types[i]))
@@ -322,7 +322,7 @@ func parseArgumentArray(dec *json.Decoder, types []reflect.Type) ([]reflect.Valu
 		if err := dec.Decode(argval.Interface()); err != nil {
 			return args, fmt.Errorf("invalid argument %d: %v", i, err)
 		}
-		if argval.IsNil() && types[i].Kind() != reflect.Ptr {
+		if argval.IsNil() && types[i].Kind() != reflect.Pointer {
 			return args, fmt.Errorf("missing value for required argument %d", i)
 		}
 		args = append(args, argval.Elem())

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -217,7 +217,7 @@ func (c *callback) call(ctx context.Context, method string, args []reflect.Value
 
 // Is t context.Context or *context.Context?
 func isContextType(t reflect.Type) bool {
-	for t.Kind() == reflect.Ptr {
+	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	return t == contextType
@@ -225,7 +225,7 @@ func isContextType(t reflect.Type) bool {
 
 // Does t satisfy the error interface?
 func isErrorType(t reflect.Type) bool {
-	for t.Kind() == reflect.Ptr {
+	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	return t.Implements(errorType)
@@ -233,7 +233,7 @@ func isErrorType(t reflect.Type) bool {
 
 // Is t Subscription or *Subscription?
 func isSubscriptionType(t reflect.Type) bool {
-	for t.Kind() == reflect.Ptr {
+	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	return t == subscriptionType


### PR DESCRIPTION
A zero-amount query in hash-origin mode computed count-1 on a uint64, underflowing to 2^64-1. That value was then clamped in ReadHeaderRange into the full canonical prefix, so a query that should return zero headers instead served the origin header plus all ancestors. Guard against count==0 at the top of serviceContiguousBlockHeaderQuery, covering both number- and hash-origin modes.