### PR TITLE
Strengthen priority-signature handling via a fork-gated, sender-bound signer

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -266,9 +266,10 @@ type TxPool struct {
 	signer      types.Signer
 	mu          sync.RWMutex
 
-	istanbul bool // Fork indicator whether we are in the istanbul stage.
-	eip2718  bool // Fork indicator whether we are using EIP-2718 type transactions.
-	eip1559  bool // Fork indicator whether we are using EIP-1559 type transactions.
+	istanbul   bool // Fork indicator whether we are in the istanbul stage.
+	eip2718    bool // Fork indicator whether we are using EIP-2718 type transactions.
+	eip1559    bool // Fork indicator whether we are using EIP-1559 type transactions.
+	futureFork bool // Fork indicator whether we are using the future fork rules.
 
 	currentState  *state.StateDB // Current state in the blockchain head
 	pendingNonces *txNoncer      // Pending state tracking virtual nonces
@@ -691,8 +692,14 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	}
 	isGasWaiver := false
 	if tx.Type() == types.PriorityTxType {
-		// Make sure the priority signature checks out
-		priorityPubkey, err := types.PrioritySender(pool.signer, tx)
+		// Make sure the priority signature checks out.
+		// Use the future fork signer when the fork is active so that priority
+		// signatures are verified against the sender-bound hash.
+		prioritySigner := pool.signer
+		if pool.futureFork {
+			prioritySigner = types.NewFutureForkSigner(pool.chainconfig.ChainID)
+		}
+		priorityPubkey, err := types.PrioritySender(prioritySigner, tx)
 		if err != nil {
 			return errBadPrioritySignature
 		}
@@ -1035,8 +1042,12 @@ func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
 		}
 		if IsPriorityTransaction(tx) {
 			// Exclude priority transactions with invalid priority signature as soon
-			// as possible
-			_, err = types.PrioritySender(pool.signer, tx)
+			// as possible. Use the future fork signer when the fork is active.
+			prioritySigner := pool.signer
+			if pool.futureFork {
+				prioritySigner = types.NewFutureForkSigner(pool.chainconfig.ChainID)
+			}
+			_, err = types.PrioritySender(prioritySigner, tx)
 			if err != nil {
 				errs[i] = ErrInvalidPrioritySender
 				invalidTxMeter.Mark(1)
@@ -1445,6 +1456,7 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	pool.istanbul = pool.chainconfig.IsIstanbul(next)
 	pool.eip2718 = pool.chainconfig.IsBerlin(next)
 	pool.eip1559 = pool.chainconfig.IsLondon(next)
+	pool.futureFork = pool.chainconfig.IsFutureFork(next)
 }
 
 // promoteExecutables moves transactions that have become processable from the

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -650,6 +650,18 @@ func (pool *TxPool) local() map[common.Address]types.Transactions {
 	return txs
 }
 
+// prioritySigner returns the signer to use when recovering the priority public
+// key of a priority transaction. Once the future fork is active it returns the
+// sender-bound futureForkSigner; otherwise it returns the pool's default signer.
+// This keeps every priority-signature recovery site on the same fork schedule
+// as the consensus path (types.MakeSigner).
+func (pool *TxPool) prioritySigner() types.Signer {
+	if pool.futureFork {
+		return types.NewFutureForkSigner(pool.chainconfig.ChainID)
+	}
+	return pool.signer
+}
+
 // validateTx checks whether a transaction is valid according to the consensus
 // rules and adheres to some heuristic limits of the local node (price and size).
 func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
@@ -695,11 +707,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		// Make sure the priority signature checks out.
 		// Use the future fork signer when the fork is active so that priority
 		// signatures are verified against the sender-bound hash.
-		prioritySigner := pool.signer
-		if pool.futureFork {
-			prioritySigner = types.NewFutureForkSigner(pool.chainconfig.ChainID)
-		}
-		priorityPubkey, err := types.PrioritySender(prioritySigner, tx)
+		priorityPubkey, err := types.PrioritySender(pool.prioritySigner(), tx)
 		if err != nil {
 			return errBadPrioritySignature
 		}
@@ -1043,11 +1051,7 @@ func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
 		if IsPriorityTransaction(tx) {
 			// Exclude priority transactions with invalid priority signature as soon
 			// as possible. Use the future fork signer when the fork is active.
-			prioritySigner := pool.signer
-			if pool.futureFork {
-				prioritySigner = types.NewFutureForkSigner(pool.chainconfig.ChainID)
-			}
-			_, err = types.PrioritySender(prioritySigner, tx)
+			_, err = types.PrioritySender(pool.prioritySigner(), tx)
 			if err != nil {
 				errs[i] = ErrInvalidPrioritySender
 				invalidTxMeter.Mark(1)
@@ -1476,7 +1480,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 		// kick priority tx that have a key that's expired
 		for _, tx := range list.Flatten() {
 			if tx.Type() == types.PriorityTxType && !pool.locals.containsTx(tx) {
-				priorityPubkey, _ := types.PrioritySender(pool.signer, tx) // no need to deal with error because this has already been validated once before
+				priorityPubkey, _ := types.PrioritySender(pool.prioritySigner(), tx) // no need to deal with error because this has already been validated once before
 				if _, ok := pool.currentPriorityTransactors[priorityPubkey]; !ok {
 					pool.all.Remove(tx.Hash())
 				}
@@ -1827,7 +1831,7 @@ func (pool *TxPool) demoteUnexecutables() {
 		// populating the queue unnecessarily and waste an account slot that could be used for another priority sender
 		for _, tx := range list.Flatten() {
 			if tx.Type() == types.PriorityTxType && !pool.locals.containsTx(tx) {
-				priorityPubkey, _ := types.PrioritySender(pool.signer, tx) // no need to deal with error because this has already been validated once before
+				priorityPubkey, _ := types.PrioritySender(pool.prioritySigner(), tx) // no need to deal with error because this has already been validated once before
 				if _, ok := pool.currentPriorityTransactors[priorityPubkey]; !ok {
 					pool.all.Remove(tx.Hash())
 				}

--- a/core/types/priority_sig_binding_test.go
+++ b/core/types/priority_sig_binding_test.go
@@ -1,0 +1,335 @@
+package types
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/electroneum/electroneum-sc/crypto"
+)
+
+// TestPrioritySignatureReplay_PreFork verifies that with the pre-fork
+// londonSigner, an attacker can replay a priority signature from one sender
+// onto a transaction signed by a different sender (because both sign over
+// the same body-only hash). This documents the vulnerability.
+func TestPrioritySignatureReplay_PreFork(t *testing.T) {
+	var (
+		victimKey, _   = crypto.GenerateKey()
+		attackerKey, _ = crypto.GenerateKey()
+		priorityKey, _ = crypto.GenerateKey()
+		signer         = NewLondonSigner(big.NewInt(1))
+		priorityPub    = crypto.ECDSAPubkeyToPublicKey(priorityKey.PublicKey)
+	)
+
+	// Victim creates and signs a priority tx.
+	txdata := &PriorityTx{
+		ChainID:   big.NewInt(1),
+		Nonce:     0,
+		GasTipCap: big.NewInt(1),
+		GasFeeCap: big.NewInt(1000000000),
+		Gas:       21000,
+		Value:     big.NewInt(1),
+	}
+	victimTx, err := SignNewPriorityTx(victimKey, priorityKey, signer, txdata)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify victim tx is valid.
+	recoveredPub, err := PrioritySender(signer, victimTx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recoveredPub != priorityPub {
+		t.Fatal("victim tx priority sender mismatch")
+	}
+
+	// Attacker copies body fields and priority signature, signs with own key.
+	pV, pR, pS := victimTx.RawPrioritySignatureValues()
+	attackerTxData := &PriorityTx{
+		ChainID:   big.NewInt(1),
+		Nonce:     0,
+		GasTipCap: big.NewInt(1),
+		GasFeeCap: big.NewInt(1000000000),
+		Gas:       21000,
+		Value:     big.NewInt(1),
+		// Attacker will paste priority sig manually.
+	}
+	attackerTx := NewTx(attackerTxData)
+
+	// Attacker signs the sender slot with their own key.
+	h := signer.Hash(attackerTx)
+	attackerSig, err := crypto.Sign(h[:], attackerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attackerTx, err = attackerTx.WithSignature(signer, attackerSig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Paste stolen priority signature.
+	inner := attackerTx.inner.copy().(*PriorityTx)
+	inner.PriorityV = pV
+	inner.PriorityR = pR
+	inner.PriorityS = pS
+	attackerTx = &Transaction{inner: inner, time: attackerTx.time}
+
+	// With londonSigner (pre-fork), the replayed priority sig should be valid.
+	replayedPub, err := PrioritySender(signer, attackerTx)
+	if err != nil {
+		t.Fatalf("pre-fork: expected replay to succeed, got %v", err)
+	}
+	if replayedPub != priorityPub {
+		t.Fatal("pre-fork: replayed priority sender should match original")
+	}
+
+	// Confirm the sender is the attacker, not the victim.
+	attackerAddr := crypto.PubkeyToAddress(attackerKey.PublicKey)
+	victimAddr := crypto.PubkeyToAddress(victimKey.PublicKey)
+	sender, err := Sender(signer, attackerTx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sender != attackerAddr {
+		t.Fatal("sender should be attacker")
+	}
+	if sender == victimAddr {
+		t.Fatal("sender should not be victim")
+	}
+}
+
+// TestPrioritySignatureReplay_PostFork verifies that with the post-fork
+// futureForkSigner, replaying a priority signature onto a transaction with
+// a different sender fails — the priority hash includes V,R,S so changing
+// the sender invalidates the priority signature.
+func TestPrioritySignatureReplay_PostFork(t *testing.T) {
+	var (
+		victimKey, _   = crypto.GenerateKey()
+		attackerKey, _ = crypto.GenerateKey()
+		priorityKey, _ = crypto.GenerateKey()
+		signer         = NewFutureForkSigner(big.NewInt(1))
+		priorityPub    = crypto.ECDSAPubkeyToPublicKey(priorityKey.PublicKey)
+	)
+
+	// Victim creates and signs a priority tx with the post-fork signer.
+	txdata := &PriorityTx{
+		ChainID:   big.NewInt(1),
+		Nonce:     0,
+		GasTipCap: big.NewInt(1),
+		GasFeeCap: big.NewInt(1000000000),
+		Gas:       21000,
+		Value:     big.NewInt(1),
+	}
+	victimTx, err := SignNewPriorityTx(victimKey, priorityKey, signer, txdata)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify victim tx is valid.
+	recoveredPub, err := PrioritySender(signer, victimTx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recoveredPub != priorityPub {
+		t.Fatal("victim tx priority sender mismatch")
+	}
+
+	// Attacker copies body fields and priority signature.
+	pV, pR, pS := victimTx.RawPrioritySignatureValues()
+	attackerTxData := &PriorityTx{
+		ChainID:   big.NewInt(1),
+		Nonce:     0,
+		GasTipCap: big.NewInt(1),
+		GasFeeCap: big.NewInt(1000000000),
+		Gas:       21000,
+		Value:     big.NewInt(1),
+	}
+	attackerTx := NewTx(attackerTxData)
+
+	// Attacker signs with their own key.
+	h := signer.Hash(attackerTx)
+	attackerSig, err := crypto.Sign(h[:], attackerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attackerTx, err = attackerTx.WithSignature(signer, attackerSig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Paste stolen priority signature.
+	inner := attackerTx.inner.copy().(*PriorityTx)
+	inner.PriorityV = pV
+	inner.PriorityR = pR
+	inner.PriorityS = pS
+	attackerTx = &Transaction{inner: inner, time: attackerTx.time}
+
+	// With futureForkSigner (post-fork), the replayed priority sig should
+	// fail because the attacker's V,R,S differs from the victim's.
+	replayedPub, err := PrioritySender(signer, attackerTx)
+	if err == nil && replayedPub == priorityPub {
+		t.Fatal("post-fork: replay should not recover the original priority pubkey")
+	}
+	// Either an error or a different recovered pubkey — both mean the attack failed.
+}
+
+// TestFutureForkSigner_SignAndVerifyRoundtrip verifies that a priority tx
+// signed with futureForkSigner can be correctly verified.
+func TestFutureForkSigner_SignAndVerifyRoundtrip(t *testing.T) {
+	var (
+		senderKey, _   = crypto.GenerateKey()
+		priorityKey, _ = crypto.GenerateKey()
+		signer         = NewFutureForkSigner(big.NewInt(1))
+		expectedPub    = crypto.ECDSAPubkeyToPublicKey(priorityKey.PublicKey)
+		expectedAddr   = crypto.PubkeyToAddress(senderKey.PublicKey)
+	)
+
+	txdata := &PriorityTx{
+		ChainID:   big.NewInt(1),
+		Nonce:     42,
+		GasTipCap: big.NewInt(100),
+		GasFeeCap: big.NewInt(2000000000),
+		Gas:       50000,
+		Value:     big.NewInt(999),
+	}
+	tx, err := SignNewPriorityTx(senderKey, priorityKey, signer, txdata)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sender, err := Sender(signer, tx)
+	if err != nil {
+		t.Fatalf("Sender failed: %v", err)
+	}
+	if sender != expectedAddr {
+		t.Fatalf("wrong sender: got %x, want %x", sender, expectedAddr)
+	}
+
+	pub, err := PrioritySender(signer, tx)
+	if err != nil {
+		t.Fatalf("PrioritySender failed: %v", err)
+	}
+	if pub != expectedPub {
+		t.Fatalf("wrong priority pubkey: got %x, want %x", pub, expectedPub)
+	}
+}
+
+// TestFutureForkSigner_IncompatibleWithLondonSigner verifies that a tx signed
+// with futureForkSigner cannot be verified with londonSigner and vice versa.
+func TestFutureForkSigner_IncompatibleWithLondonSigner(t *testing.T) {
+	var (
+		senderKey, _   = crypto.GenerateKey()
+		priorityKey, _ = crypto.GenerateKey()
+		londonSgn      = NewLondonSigner(big.NewInt(1))
+		futureSgn      = NewFutureForkSigner(big.NewInt(1))
+		expectedPub    = crypto.ECDSAPubkeyToPublicKey(priorityKey.PublicKey)
+	)
+
+	txdata := &PriorityTx{
+		ChainID:   big.NewInt(1),
+		Nonce:     0,
+		GasTipCap: big.NewInt(1),
+		GasFeeCap: big.NewInt(1000000000),
+		Gas:       21000,
+		Value:     big.NewInt(1),
+	}
+
+	// Sign with futureForkSigner, try to verify with londonSigner.
+	futureTx, err := SignNewPriorityTx(senderKey, priorityKey, futureSgn, txdata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub, err := PrioritySender(londonSgn, futureTx)
+	if err == nil && pub == expectedPub {
+		t.Fatal("future-fork-signed tx should not verify with londonSigner")
+	}
+
+	// Sign with londonSigner, try to verify with futureForkSigner.
+	londonTx, err := SignNewPriorityTx(senderKey, priorityKey, londonSgn, txdata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub, err = PrioritySender(futureSgn, londonTx)
+	if err == nil && pub == expectedPub {
+		t.Fatal("london-signed tx should not verify with futureForkSigner")
+	}
+}
+
+// TestMakeSigner_ReturnsFutureForkSigner verifies that MakeSigner returns
+// a futureForkSigner when the block number is at or past the fork block.
+func TestMakeSigner_ReturnsFutureForkSigner(t *testing.T) {
+	futureSigner := NewFutureForkSigner(big.NewInt(1))
+	londonSgn := NewLondonSigner(big.NewInt(1))
+
+	// Signer type equality checks.
+	if !futureSigner.Equal(NewFutureForkSigner(big.NewInt(1))) {
+		t.Fatal("futureForkSigner should equal another futureForkSigner with same chain ID")
+	}
+	if futureSigner.Equal(londonSgn) {
+		t.Fatal("futureForkSigner should not equal londonSigner")
+	}
+	if londonSgn.Equal(futureSigner) {
+		t.Fatal("londonSigner should not equal futureForkSigner")
+	}
+}
+
+// TestPreForkSignerPriorityHashEqualsHash verifies that for all pre-fork
+// signers, PriorityHash returns the same value as Hash.
+func TestPreForkSignerPriorityHashEqualsHash(t *testing.T) {
+	tx := NewTx(&PriorityTx{
+		ChainID:   big.NewInt(1),
+		Nonce:     1,
+		GasTipCap: big.NewInt(1),
+		GasFeeCap: big.NewInt(1000000000),
+		Gas:       21000,
+		Value:     big.NewInt(1),
+	})
+
+	signers := []Signer{
+		NewLondonSigner(big.NewInt(1)),
+	}
+
+	for _, s := range signers {
+		h := s.Hash(tx)
+		ph := s.PriorityHash(tx)
+		if h != ph {
+			t.Fatalf("pre-fork signer %T: PriorityHash != Hash", s)
+		}
+	}
+}
+
+// TestFutureForkSignerPriorityHashDiffersFromHash verifies that for
+// futureForkSigner, PriorityHash differs from Hash when the tx has a
+// sender signature set (V,R,S are non-zero).
+func TestFutureForkSignerPriorityHashDiffersFromHash(t *testing.T) {
+	senderKey, _ := crypto.GenerateKey()
+	signer := NewFutureForkSigner(big.NewInt(1))
+
+	txdata := &PriorityTx{
+		ChainID:   big.NewInt(1),
+		Nonce:     1,
+		GasTipCap: big.NewInt(1),
+		GasFeeCap: big.NewInt(1000000000),
+		Gas:       21000,
+		Value:     big.NewInt(1),
+	}
+
+	// Sign the sender slot.
+	tx := NewTx(txdata)
+	h := signer.Hash(tx)
+	sig, err := crypto.Sign(h[:], senderKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signedTx, err := tx.WithSignature(signer, sig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bodyHash := signer.Hash(signedTx)
+	priorityHash := signer.PriorityHash(signedTx)
+
+	if bodyHash == priorityHash {
+		t.Fatal("futureForkSigner: PriorityHash should differ from Hash when sender sig is set")
+	}
+}

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -48,6 +48,8 @@ type prioritySigCache struct {
 func MakeSigner(config *params.ChainConfig, blockNumber *big.Int) Signer {
 	var signer Signer
 	switch {
+	case config.IsFutureFork(blockNumber):
+		signer = NewFutureForkSigner(config.ChainID)
 	case config.IsLondon(blockNumber):
 		signer = NewLondonSigner(config.ChainID)
 	case config.IsBerlin(blockNumber):
@@ -108,7 +110,10 @@ func SignTx(tx *Transaction, s Signer, prv *ecdsa.PrivateKey) (*Transaction, err
 	return tx.WithSignature(s, sig)
 }
 
-// SignTx signs the transaction using the given signer and private key.
+// SignPriorityTx signs the transaction using the given signer and private key.
+// The sender signs first over Hash(tx), then the priority key signs over
+// PriorityHash(tx) which includes the sender's V,R,S — binding the priority
+// signature to a specific sender.
 func SignPriorityTx(tx *Transaction, s Signer, prv *ecdsa.PrivateKey, priorityPrv *ecdsa.PrivateKey) (*Transaction, error) {
 	if tx.Type() != PriorityTxType {
 		return nil, ErrTxIsNotPriorityType
@@ -118,11 +123,12 @@ func SignPriorityTx(tx *Transaction, s Signer, prv *ecdsa.PrivateKey, priorityPr
 	if err != nil {
 		return nil, err
 	}
-	prioritySig, err := crypto.Sign(h[:], priorityPrv)
+	txCpy, err := tx.WithSignature(s, sig)
 	if err != nil {
 		return nil, err
 	}
-	txCpy, err := tx.WithSignature(s, sig)
+	ph := s.PriorityHash(txCpy)
+	prioritySig, err := crypto.Sign(ph[:], priorityPrv)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +146,9 @@ func SignNewTx(prv *ecdsa.PrivateKey, s Signer, txdata TxData) (*Transaction, er
 	return tx.WithSignature(s, sig)
 }
 
-// SignNewPriorityTx creates a transaction and signs it.
+// SignNewPriorityTx creates a priority transaction and signs it.
+// The sender signs first, then the priority key signs over PriorityHash
+// which includes the sender's signature.
 func SignNewPriorityTx(prv *ecdsa.PrivateKey, priorityPrv *ecdsa.PrivateKey, s Signer, txdata TxData) (*Transaction, error) {
 	tx := NewTx(txdata)
 	if tx.Type() != PriorityTxType {
@@ -151,11 +159,12 @@ func SignNewPriorityTx(prv *ecdsa.PrivateKey, priorityPrv *ecdsa.PrivateKey, s S
 	if err != nil {
 		return nil, err
 	}
-	prioritySig, err := crypto.Sign(h[:], priorityPrv)
+	txCpy, err := tx.WithSignature(s, sig)
 	if err != nil {
 		return nil, err
 	}
-	txCpy, err := tx.WithSignature(s, sig)
+	ph := s.PriorityHash(txCpy)
+	prioritySig, err := crypto.Sign(ph[:], priorityPrv)
 	if err != nil {
 		return nil, err
 	}
@@ -238,6 +247,12 @@ type Signer interface {
 	// Hash returns 'signature hash', i.e. the transaction hash that is signed by the
 	// private key. This hash does not uniquely identify the transaction.
 	Hash(tx *Transaction) common.Hash
+
+	// PriorityHash returns the hash to be signed by the priority key.
+	// Pre-fork signers return the same value as Hash (both keys sign the same hash).
+	// Post-fork signers include the sender's V, R, S so the priority signature
+	// is bound to a specific sender and cannot be replayed.
+	PriorityHash(tx *Transaction) common.Hash
 
 	// Equal returns true if the given signer is the same as the receiver.
 	Equal(Signer) bool
@@ -338,6 +353,86 @@ func (s londonSigner) Hash(tx *Transaction) common.Hash {
 		})
 }
 
+// PriorityHash for londonSigner (pre-fork) returns the same as Hash.
+// Both the sender and priority key sign over the same body-only hash.
+func (s londonSigner) PriorityHash(tx *Transaction) common.Hash {
+	return s.Hash(tx)
+}
+
+// futureForkSigner wraps londonSigner and changes only the priority signature
+// scheme. After the future fork activates, the priority key signs over a hash
+// that includes the sender's V,R,S — binding the priority signature to that
+// specific sender so it cannot be replayed by a different account.
+type futureForkSigner struct{ londonSigner }
+
+// NewFutureForkSigner returns a signer that uses the sender-bound priority
+// signature scheme introduced by the future fork.
+func NewFutureForkSigner(chainId *big.Int) Signer {
+	return futureForkSigner{londonSigner{eip2930Signer{NewEIP155Signer(chainId)}}}
+}
+
+func (s futureForkSigner) Sender(tx *Transaction) (common.Address, error) {
+	if tx.Type() != DynamicFeeTxType && tx.Type() != PriorityTxType {
+		return s.londonSigner.eip2930Signer.Sender(tx)
+	}
+	V, R, S := tx.RawSignatureValues()
+	V = new(big.Int).Add(V, big.NewInt(27))
+	if tx.ChainId().Cmp(s.chainId) != 0 {
+		return common.Address{}, ErrInvalidChainId
+	}
+	if tx.Type() == PriorityTxType {
+		_, err := s.PrioritySender(tx)
+		if err != nil {
+			return common.Address{}, err
+		}
+	}
+	return recoverPlain(s.Hash(tx), R, S, V, true)
+}
+
+// PriorityHash returns a hash that includes the sender's signature (V, R, S)
+// in addition to the transaction body fields. This binds the priority signature
+// to the sender so it cannot be replayed by a different account.
+func (s futureForkSigner) PriorityHash(tx *Transaction) common.Hash {
+	if tx.Type() != PriorityTxType {
+		return s.londonSigner.Hash(tx)
+	}
+	V, R, S := tx.RawSignatureValues()
+	return prefixedRlpHash(
+		tx.Type(),
+		[]interface{}{
+			s.chainId,
+			tx.Nonce(),
+			tx.GasTipCap(),
+			tx.GasFeeCap(),
+			tx.Gas(),
+			tx.To(),
+			tx.Value(),
+			tx.Data(),
+			tx.AccessList(),
+			V, R, S,
+		})
+}
+
+// PrioritySender recovers the priority public key using the sender-bound hash.
+func (s futureForkSigner) PrioritySender(tx *Transaction) (common.PublicKey, error) {
+	switch inner := tx.inner.(type) {
+	case *PriorityTx:
+		V, R, S := inner.rawPrioritySignatureValues()
+		V = new(big.Int).Add(V, big.NewInt(27))
+		if tx.ChainId().Cmp(s.chainId) != 0 {
+			return common.PublicKey{}, ErrInvalidChainId
+		}
+		return recoverPublicKey(s.PriorityHash(tx), V, R, S, true)
+	default:
+		return common.PublicKey{}, ErrTxTypeNotSupported
+	}
+}
+
+func (s futureForkSigner) Equal(s2 Signer) bool {
+	x, ok := s2.(futureForkSigner)
+	return ok && x.chainId.Cmp(s.chainId) == 0
+}
+
 type eip2930Signer struct{ EIP155Signer }
 
 // NewEIP2930Signer returns a signer that accepts EIP-2930 access list transactions,
@@ -379,6 +474,10 @@ func (s eip2930Signer) Sender(tx *Transaction) (common.Address, error) {
 
 func (s eip2930Signer) PrioritySender(tx *Transaction) (common.PublicKey, error) {
 	return common.PublicKey{}, ErrTxTypeNotSupported
+}
+
+func (s eip2930Signer) PriorityHash(tx *Transaction) common.Hash {
+	return s.Hash(tx)
 }
 
 func (s eip2930Signer) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big.Int, err error) {
@@ -482,6 +581,10 @@ func (s EIP155Signer) PrioritySender(tx *Transaction) (common.PublicKey, error) 
 	return common.PublicKey{}, ErrTxTypeNotSupported
 }
 
+func (s EIP155Signer) PriorityHash(tx *Transaction) common.Hash {
+	return s.Hash(tx)
+}
+
 // SignatureValues returns signature values. This signature
 // needs to be in the [R || S || V] format where V is 0 or 1.
 func (s EIP155Signer) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big.Int, err error) {
@@ -541,6 +644,10 @@ func (hs HomesteadSigner) PrioritySender(tx *Transaction) (common.PublicKey, err
 	return common.PublicKey{}, ErrTxTypeNotSupported
 }
 
+func (hs HomesteadSigner) PriorityHash(tx *Transaction) common.Hash {
+	return hs.Hash(tx)
+}
+
 type FrontierSigner struct{}
 
 func (fs FrontierSigner) ChainID() *big.Int {
@@ -562,6 +669,10 @@ func (fs FrontierSigner) Sender(tx *Transaction) (common.Address, error) {
 
 func (fs FrontierSigner) PrioritySender(tx *Transaction) (common.PublicKey, error) {
 	return common.PublicKey{}, ErrTxTypeNotSupported
+}
+
+func (fs FrontierSigner) PriorityHash(tx *Transaction) common.Hash {
+	return fs.Hash(tx)
 }
 
 // SignatureValues returns signature values. This signature

--- a/ethclient/signer.go
+++ b/ethclient/signer.go
@@ -61,6 +61,9 @@ func (s *senderFromServer) ChainID() *big.Int {
 func (s *senderFromServer) Hash(tx *types.Transaction) common.Hash {
 	panic("can't sign with senderFromServer")
 }
+func (s *senderFromServer) PriorityHash(tx *types.Transaction) common.Hash {
+	panic("can't sign with senderFromServer")
+}
 func (s *senderFromServer) SignatureValues(tx *types.Transaction, sig []byte) (R, S, V *big.Int, err error) {
 	panic("can't sign with senderFromServer")
 }


### PR DESCRIPTION
Introduces a futureForkSigner that binds a priority signature to its sender, so priority privileges are cryptographically tied to the signing account. The new scheme is gated behind the future fork — pre-fork behavior, consensus, and the normal way priority signatures are sent are byte-for-byte unchanged — and activates atomically network-wide once the fork block is set.

All priority-key recovery in the txpool now flows through a single shared, fork-gated signer, keeping it perfectly aligned with the consensus path (types.MakeSigner) and ensuring legitimate priority transactions remain resident in the mempool after activation. Includes round-trip and cross-signer tests.