### PR TITLE
eth/filters: add optional block-range limit for log queries to prevent DoS

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -695,7 +695,7 @@ func (b *SimulatedBackend) FilterLogs(ctx context.Context, query electroneum.Fil
 			to = query.ToBlock.Int64()
 		}
 		// Construct the range filter
-		filter = filters.NewRangeFilter(&filterBackend{b.database, b.blockchain}, from, to, query.Addresses, query.Topics)
+		filter = filters.NewRangeFilter(&filterBackend{b.database, b.blockchain}, from, to, query.Addresses, query.Topics, 0)
 	}
 	// Run the filter and return all the logs
 	logs, err := filter.Logs(ctx)

--- a/cmd/etn-sc/config.go
+++ b/cmd/etn-sc/config.go
@@ -175,7 +175,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 
 	// Configure GraphQL if requested
 	if ctx.GlobalIsSet(utils.GraphQLEnabledFlag.Name) {
-		utils.RegisterGraphQLService(stack, backend, cfg.Node, cfg.Eth.RPCLogQueryLimit)
+		utils.RegisterGraphQLService(stack, backend, cfg.Node, cfg.Eth.RPCLogQueryLimit, cfg.Eth.RangeLimit)
 	}
 	// Add the Ethereum Stats daemon if requested.
 	if cfg.Ethstats.URL != "" {

--- a/cmd/etn-sc/main.go
+++ b/cmd/etn-sc/main.go
@@ -185,6 +185,7 @@ var (
 		utils.RPCGlobalEVMTimeoutFlag,
 		utils.RPCGlobalTxFeeCapFlag,
 		utils.RPCGlobalLogQueryLimitFlag,
+		utils.RPCGlobalRangeLimitFlag,
 		utils.AllowUnprotectedTxs,
 	}
 

--- a/cmd/etn-sc/usage.go
+++ b/cmd/etn-sc/usage.go
@@ -155,6 +155,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.RPCGlobalEVMTimeoutFlag,
 			utils.RPCGlobalTxFeeCapFlag,
 			utils.RPCGlobalLogQueryLimitFlag,
+			utils.RPCGlobalRangeLimitFlag,
 			utils.AllowUnprotectedTxs,
 			utils.JSpathFlag,
 			utils.ExecFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -540,6 +540,11 @@ var (
 		Usage: "Sets a cap on the number of addresses and per-position topics accepted by eth_getLogs, eth_newFilter, eth_subscribe(logs), eth_getFilterLogs, and the GraphQL logs resolvers (0 = no cap)",
 		Value: ethconfig.Defaults.RPCLogQueryLimit,
 	}
+	RPCGlobalRangeLimitFlag = cli.Uint64Flag{
+		Name:  "rpc.rangelimit",
+		Usage: "Sets a cap on the block range (toBlock - fromBlock) accepted by eth_getLogs, eth_getFilterLogs, and the GraphQL logs resolvers (0 = no cap)",
+		Value: ethconfig.Defaults.RangeLimit,
+	}
 	// Authenticated RPC HTTP settings
 	AuthListenFlag = cli.StringFlag{
 		Name:  "authrpc.addr",
@@ -1683,6 +1688,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.GlobalIsSet(RPCGlobalLogQueryLimitFlag.Name) {
 		cfg.RPCLogQueryLimit = ctx.GlobalInt(RPCGlobalLogQueryLimitFlag.Name)
 	}
+	if ctx.GlobalIsSet(RPCGlobalRangeLimitFlag.Name) {
+		cfg.RangeLimit = ctx.GlobalUint64(RPCGlobalRangeLimitFlag.Name)
+	}
 	if ctx.GlobalIsSet(NoDiscoverFlag.Name) {
 		cfg.EthDiscoveryURLs, cfg.SnapDiscoveryURLs = []string{}, []string{}
 	} else if ctx.GlobalIsSet(DNSDiscoveryFlag.Name) {
@@ -1834,8 +1842,8 @@ func RegisterEthStatsService(stack *node.Node, backend ethapi.Backend, url strin
 }
 
 // RegisterGraphQLService is a utility function to construct a new service and register it against a node.
-func RegisterGraphQLService(stack *node.Node, backend ethapi.Backend, cfg node.Config, logQueryLimit int) {
-	if err := graphql.New(stack, backend, cfg.GraphQLCors, cfg.GraphQLVirtualHosts, logQueryLimit); err != nil {
+func RegisterGraphQLService(stack *node.Node, backend ethapi.Backend, cfg node.Config, logQueryLimit int, rangeLimit uint64) {
+	if err := graphql.New(stack, backend, cfg.GraphQLCors, cfg.GraphQLVirtualHosts, logQueryLimit, rangeLimit); err != nil {
 		Fatalf("Failed to register the GraphQL service: %v", err)
 	}
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -349,7 +349,7 @@ func (s *Ethereum) APIs() []rpc.API {
 		}, {
 			Namespace: "eth",
 			Version:   "1.0",
-			Service:   filters.NewPublicFilterAPI(s.APIBackend, false, 5*time.Minute, s.config.RPCLogQueryLimit),
+			Service:   filters.NewPublicFilterAPI(s.APIBackend, false, 5*time.Minute, s.config.RPCLogQueryLimit, s.config.RangeLimit),
 			Public:    true,
 		}, {
 			Namespace: "admin",

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -96,6 +96,7 @@ var Defaults = Config{
 	GPO:              FullNodeGPO,
 	RPCTxFeeCap:      100000, //  [[ETH($)/ETN($)] / 20(to allow for appreciation, and given that fees will start very low] : correct to jun 2023
 	RPCLogQueryLimit: 1000,
+	RangeLimit:       0, // disabled by default, matching upstream go-ethereum
 
 	// Quorum
 	Istanbul: *istanbul.DefaultConfig, // Quorum
@@ -213,6 +214,11 @@ type Config struct {
 	// eth_subscribe("logs"), eth_getFilterLogs, and the GraphQL logs resolvers).
 	// 0 disables the cap.
 	RPCLogQueryLimit int
+
+	// RangeLimit restricts the maximum block range (end - begin) accepted by
+	// range log queries (eth_getLogs, eth_getFilterLogs and the GraphQL logs
+	// resolvers). 0 disables the cap. Mirrors upstream go-ethereum.
+	RangeLimit uint64 `toml:",omitempty"`
 
 	// Checkpoint is a hardcoded checkpoint which can be nil.
 	Checkpoint *params.TrustedCheckpoint `toml:",omitempty"`

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -59,6 +59,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		RPCEVMTimeout                   time.Duration
 		RPCTxFeeCap                     float64
 		RPCLogQueryLimit                int
+		RangeLimit                      uint64                         `toml:",omitempty"`
 		Checkpoint                      *params.TrustedCheckpoint      `toml:",omitempty"`
 		CheckpointOracle                *params.CheckpointOracleConfig `toml:",omitempty"`
 		OverrideArrowGlacier            *big.Int                       `toml:",omitempty"`
@@ -106,6 +107,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.RPCEVMTimeout = c.RPCEVMTimeout
 	enc.RPCTxFeeCap = c.RPCTxFeeCap
 	enc.RPCLogQueryLimit = c.RPCLogQueryLimit
+	enc.RangeLimit = c.RangeLimit
 	enc.Checkpoint = c.Checkpoint
 	enc.CheckpointOracle = c.CheckpointOracle
 	enc.OverrideArrowGlacier = c.OverrideArrowGlacier
@@ -157,6 +159,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		RPCEVMTimeout                   *time.Duration
 		RPCTxFeeCap                     *float64
 		RPCLogQueryLimit                *int
+		RangeLimit                      *uint64                        `toml:",omitempty"`
 		Checkpoint                      *params.TrustedCheckpoint      `toml:",omitempty"`
 		CheckpointOracle                *params.CheckpointOracleConfig `toml:",omitempty"`
 		OverrideArrowGlacier            *big.Int                       `toml:",omitempty"`
@@ -286,6 +289,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.RPCLogQueryLimit != nil {
 		c.RPCLogQueryLimit = *dec.RPCLogQueryLimit
+	}
+	if dec.RangeLimit != nil {
+		c.RangeLimit = *dec.RangeLimit
 	}
 	if dec.Checkpoint != nil {
 		c.Checkpoint = dec.Checkpoint

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -56,19 +56,22 @@ type PublicFilterAPI struct {
 	filters       map[rpc.ID]*filter
 	timeout       time.Duration
 	logQueryLimit int
+	rangeLimit    uint64
 }
 
 // NewPublicFilterAPI returns a new PublicFilterAPI instance.
 //
 // logQueryLimit caps the number of addresses and per-position topics accepted
-// by log-filter methods. 0 disables the cap.
-func NewPublicFilterAPI(backend Backend, lightMode bool, timeout time.Duration, logQueryLimit int) *PublicFilterAPI {
+// by log-filter methods. rangeLimit caps the block range (end - begin) accepted
+// by range log queries. 0 disables either cap.
+func NewPublicFilterAPI(backend Backend, lightMode bool, timeout time.Duration, logQueryLimit int, rangeLimit uint64) *PublicFilterAPI {
 	api := &PublicFilterAPI{
 		backend:       backend,
 		events:        NewEventSystem(backend, lightMode),
 		filters:       make(map[rpc.ID]*filter),
 		timeout:       timeout,
 		logQueryLimit: logQueryLimit,
+		rangeLimit:    rangeLimit,
 	}
 	go api.timeoutLoop(timeout)
 
@@ -379,7 +382,7 @@ func (api *PublicFilterAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([
 			end = crit.ToBlock.Int64()
 		}
 		// Construct the range filter
-		filter = NewRangeFilter(api.backend, begin, end, crit.Addresses, crit.Topics)
+		filter = NewRangeFilter(api.backend, begin, end, crit.Addresses, crit.Topics, api.rangeLimit)
 	}
 	// Run the filter and return all the logs
 	logs, err := filter.Logs(ctx)
@@ -437,7 +440,7 @@ func (api *PublicFilterAPI) GetFilterLogs(ctx context.Context, id rpc.ID) ([]*ty
 			end = f.crit.ToBlock.Int64()
 		}
 		// Construct the range filter
-		filter = NewRangeFilter(api.backend, begin, end, f.crit.Addresses, f.crit.Topics)
+		filter = NewRangeFilter(api.backend, begin, end, f.crit.Addresses, f.crit.Topics, api.rangeLimit)
 	}
 	// Run the filter and return all the logs
 	logs, err := filter.Logs(ctx)

--- a/eth/filters/bench_test.go
+++ b/eth/filters/bench_test.go
@@ -133,7 +133,7 @@ func benchmarkBloomBits(b *testing.B, sectionSize uint64) {
 		var addr common.Address
 		addr[0] = byte(i)
 		addr[1] = byte(i / 256)
-		filter := NewRangeFilter(backend, 0, int64(cnt*sectionSize-1), []common.Address{addr}, nil)
+		filter := NewRangeFilter(backend, 0, int64(cnt*sectionSize-1), []common.Address{addr}, nil, 0)
 		if _, err := filter.Logs(context.Background()); err != nil {
 			b.Error("filter.Find error:", err)
 		}
@@ -174,7 +174,7 @@ func BenchmarkNoBloomBits(b *testing.B) {
 	b.Log("Running filter benchmarks...")
 	start := time.Now()
 	backend := &testBackend{db: db}
-	filter := NewRangeFilter(backend, 0, int64(*headNum), []common.Address{{}}, nil)
+	filter := NewRangeFilter(backend, 0, int64(*headNum), []common.Address{{}}, nil, 0)
 	filter.Logs(context.Background())
 	d := time.Since(start)
 	b.Log("Finished running filter benchmarks")

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -19,6 +19,7 @@ package filters
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/electroneum/electroneum-sc/common"
@@ -57,13 +58,14 @@ type Filter struct {
 
 	block      common.Hash // Block hash if filtering a single block
 	begin, end int64       // Range interval if filtering multiple blocks
+	rangeLimit uint64      // Maximum block range (end - begin) allowed; 0 disables the cap
 
 	matcher *bloombits.Matcher
 }
 
 // NewRangeFilter creates a new filter which uses a bloom filter on blocks to
 // figure out whether a particular block is interesting or not.
-func NewRangeFilter(backend Backend, begin, end int64, addresses []common.Address, topics [][]common.Hash) *Filter {
+func NewRangeFilter(backend Backend, begin, end int64, addresses []common.Address, topics [][]common.Hash, rangeLimit uint64) *Filter {
 	// Flatten the address and topic filter clauses into a single bloombits filter
 	// system. Since the bloombits are not positional, nil topics are permitted,
 	// which get flattened into a nil byte slice.
@@ -90,6 +92,7 @@ func NewRangeFilter(backend Backend, begin, end int64, addresses []common.Addres
 	filter.matcher = bloombits.NewMatcher(size, filters)
 	filter.begin = begin
 	filter.end = end
+	filter.rangeLimit = rangeLimit
 
 	return filter
 }
@@ -141,6 +144,12 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 	end := uint64(f.end)
 	if f.end == -1 {
 		end = head
+	}
+	// Enforce the configured block-range cap once the special "latest" (-1)
+	// markers have been resolved to concrete block numbers. Mirrors upstream
+	// go-ethereum; 0 disables the cap (the default).
+	if f.rangeLimit != 0 && end >= uint64(f.begin) && end-uint64(f.begin) > f.rangeLimit {
+		return nil, fmt.Errorf("exceed maximum block range %d", f.rangeLimit)
 	}
 	// Gather all indexed logs, and finish with non indexed ones
 	var (

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -167,7 +167,7 @@ func TestBlockSubscription(t *testing.T) {
 	var (
 		db          = rawdb.NewMemoryDatabase()
 		backend     = &testBackend{db: db}
-		api         = NewPublicFilterAPI(backend, false, deadline, 0)
+		api         = NewPublicFilterAPI(backend, false, deadline, 0, 0)
 		genesis     = (&core.Genesis{BaseFee: big.NewInt(params.InitialBaseFee)}).MustCommit(db)
 		chain, _    = core.GenerateChain(params.TestChainConfig, genesis, ethash.NewFaker(), db, 10, func(i int, gen *core.BlockGen) {})
 		chainEvents = []core.ChainEvent{}
@@ -219,7 +219,7 @@ func TestPendingTxFilter(t *testing.T) {
 	var (
 		db      = rawdb.NewMemoryDatabase()
 		backend = &testBackend{db: db}
-		api     = NewPublicFilterAPI(backend, false, deadline, 0)
+		api     = NewPublicFilterAPI(backend, false, deadline, 0, 0)
 
 		transactions = []*types.Transaction{
 			types.NewTransaction(0, common.HexToAddress("0xb794f5ea0ba39494ce83a213fffba74279579268"), new(big.Int), 0, new(big.Int), nil),
@@ -274,7 +274,7 @@ func TestLogFilterCreation(t *testing.T) {
 	var (
 		db      = rawdb.NewMemoryDatabase()
 		backend = &testBackend{db: db}
-		api     = NewPublicFilterAPI(backend, false, deadline, 0)
+		api     = NewPublicFilterAPI(backend, false, deadline, 0, 0)
 
 		testCases = []struct {
 			crit    FilterCriteria
@@ -321,7 +321,7 @@ func TestInvalidLogFilterCreation(t *testing.T) {
 	var (
 		db      = rawdb.NewMemoryDatabase()
 		backend = &testBackend{db: db}
-		api     = NewPublicFilterAPI(backend, false, deadline, 0)
+		api     = NewPublicFilterAPI(backend, false, deadline, 0, 0)
 	)
 
 	// different situations where log filter creation should fail.
@@ -343,7 +343,7 @@ func TestInvalidGetLogsRequest(t *testing.T) {
 	var (
 		db        = rawdb.NewMemoryDatabase()
 		backend   = &testBackend{db: db}
-		api       = NewPublicFilterAPI(backend, false, deadline, 0)
+		api       = NewPublicFilterAPI(backend, false, deadline, 0, 0)
 		blockHash = common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
 	)
 
@@ -368,7 +368,7 @@ func TestLogFilter(t *testing.T) {
 	var (
 		db      = rawdb.NewMemoryDatabase()
 		backend = &testBackend{db: db}
-		api     = NewPublicFilterAPI(backend, false, deadline, 0)
+		api     = NewPublicFilterAPI(backend, false, deadline, 0, 0)
 
 		firstAddr      = common.HexToAddress("0x1111111111111111111111111111111111111111")
 		secondAddr     = common.HexToAddress("0x2222222222222222222222222222222222222222")
@@ -482,7 +482,7 @@ func TestPendingLogsSubscription(t *testing.T) {
 	var (
 		db      = rawdb.NewMemoryDatabase()
 		backend = &testBackend{db: db}
-		api     = NewPublicFilterAPI(backend, false, deadline, 0)
+		api     = NewPublicFilterAPI(backend, false, deadline, 0, 0)
 
 		firstAddr      = common.HexToAddress("0x1111111111111111111111111111111111111111")
 		secondAddr     = common.HexToAddress("0x2222222222222222222222222222222222222222")
@@ -666,7 +666,7 @@ func TestPendingTxFilterDeadlock(t *testing.T) {
 	var (
 		db      = rawdb.NewMemoryDatabase()
 		backend = &testBackend{db: db}
-		api     = NewPublicFilterAPI(backend, false, timeout, 0)
+		api     = NewPublicFilterAPI(backend, false, timeout, 0, 0)
 		done    = make(chan struct{})
 	)
 

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -82,7 +82,7 @@ func BenchmarkFilters(b *testing.B) {
 	}
 	b.ResetTimer()
 
-	filter := NewRangeFilter(backend, 0, -1, []common.Address{addr1, addr2, addr3, addr4}, nil)
+	filter := NewRangeFilter(backend, 0, -1, []common.Address{addr1, addr2, addr3, addr4}, nil, 0)
 
 	for i := 0; i < b.N; i++ {
 		logs, _ := filter.Logs(context.Background())
@@ -161,14 +161,14 @@ func TestFilters(t *testing.T) {
 		rawdb.WriteReceipts(db, block.Hash(), block.NumberU64(), receipts[i])
 	}
 
-	filter := NewRangeFilter(backend, 0, -1, []common.Address{addr}, [][]common.Hash{{hash1, hash2, hash3, hash4}})
+	filter := NewRangeFilter(backend, 0, -1, []common.Address{addr}, [][]common.Hash{{hash1, hash2, hash3, hash4}}, 0)
 
 	logs, _ := filter.Logs(context.Background())
 	if len(logs) != 4 {
 		t.Error("expected 4 log, got", len(logs))
 	}
 
-	filter = NewRangeFilter(backend, 900, 999, []common.Address{addr}, [][]common.Hash{{hash3}})
+	filter = NewRangeFilter(backend, 900, 999, []common.Address{addr}, [][]common.Hash{{hash3}}, 0)
 	logs, _ = filter.Logs(context.Background())
 	if len(logs) != 1 {
 		t.Error("expected 1 log, got", len(logs))
@@ -177,7 +177,7 @@ func TestFilters(t *testing.T) {
 		t.Errorf("expected log[0].Topics[0] to be %x, got %x", hash3, logs[0].Topics[0])
 	}
 
-	filter = NewRangeFilter(backend, 990, -1, []common.Address{addr}, [][]common.Hash{{hash3}})
+	filter = NewRangeFilter(backend, 990, -1, []common.Address{addr}, [][]common.Hash{{hash3}}, 0)
 	logs, _ = filter.Logs(context.Background())
 	if len(logs) != 1 {
 		t.Error("expected 1 log, got", len(logs))
@@ -186,7 +186,7 @@ func TestFilters(t *testing.T) {
 		t.Errorf("expected log[0].Topics[0] to be %x, got %x", hash3, logs[0].Topics[0])
 	}
 
-	filter = NewRangeFilter(backend, 1, 10, nil, [][]common.Hash{{hash1, hash2}})
+	filter = NewRangeFilter(backend, 1, 10, nil, [][]common.Hash{{hash1, hash2}}, 0)
 
 	logs, _ = filter.Logs(context.Background())
 	if len(logs) != 2 {
@@ -194,7 +194,7 @@ func TestFilters(t *testing.T) {
 	}
 
 	failHash := common.BytesToHash([]byte("fail"))
-	filter = NewRangeFilter(backend, 0, -1, nil, [][]common.Hash{{failHash}})
+	filter = NewRangeFilter(backend, 0, -1, nil, [][]common.Hash{{failHash}}, 0)
 
 	logs, _ = filter.Logs(context.Background())
 	if len(logs) != 0 {
@@ -202,14 +202,14 @@ func TestFilters(t *testing.T) {
 	}
 
 	failAddr := common.BytesToAddress([]byte("failmenow"))
-	filter = NewRangeFilter(backend, 0, -1, []common.Address{failAddr}, nil)
+	filter = NewRangeFilter(backend, 0, -1, []common.Address{failAddr}, nil, 0)
 
 	logs, _ = filter.Logs(context.Background())
 	if len(logs) != 0 {
 		t.Error("expected 0 log, got", len(logs))
 	}
 
-	filter = NewRangeFilter(backend, 0, -1, nil, [][]common.Hash{{failHash}, {hash1}})
+	filter = NewRangeFilter(backend, 0, -1, nil, [][]common.Hash{{failHash}, {hash1}}, 0)
 
 	logs, _ = filter.Logs(context.Background())
 	if len(logs) != 0 {

--- a/eth/filters/log_query_limit_test.go
+++ b/eth/filters/log_query_limit_test.go
@@ -20,10 +20,14 @@ import (
 	"context"
 	"errors"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/electroneum/electroneum-sc/common"
+	"github.com/electroneum/electroneum-sc/consensus/ethash"
+	"github.com/electroneum/electroneum-sc/core"
 	"github.com/electroneum/electroneum-sc/core/rawdb"
+	"github.com/electroneum/electroneum-sc/params"
 )
 
 // makeAddresses returns n distinct synthetic addresses.
@@ -48,7 +52,7 @@ func makeTopics(n int) [][]common.Hash {
 // database with the supplied log-query cap.
 func newAPIWithLimit(limit int) *PublicFilterAPI {
 	backend := &testBackend{db: rawdb.NewMemoryDatabase()}
-	return NewPublicFilterAPI(backend, false, deadline, limit)
+	return NewPublicFilterAPI(backend, false, deadline, limit, 0)
 }
 
 func TestCheckLogQueryLimit(t *testing.T) {
@@ -170,4 +174,52 @@ func TestUnderLimitIsAccepted(t *testing.T) {
 	if _, err := api.NewFilter(crit); errors.Is(err, ErrExceedLogQueryLimit) {
 		t.Fatalf("NewFilter: unexpected ErrExceedLogQueryLimit at exact cap")
 	}
+}
+
+// newBackendWithChain returns a testBackend whose canonical chain has the given
+// number of blocks above genesis, so that "latest" resolves to height n.
+func newBackendWithChain(t *testing.T, n int) *testBackend {
+	t.Helper()
+	db := rawdb.NewMemoryDatabase()
+	addr := common.BytesToAddress([]byte("tester"))
+	genesis := core.GenesisBlockForTesting(db, addr, big.NewInt(1000000))
+	chain, receipts := core.GenerateChain(params.TestChainConfig, genesis, ethash.NewFaker(), db, n, func(i int, gen *core.BlockGen) {})
+	for i, block := range chain {
+		rawdb.WriteBlock(db, block)
+		rawdb.WriteCanonicalHash(db, block.Hash(), block.NumberU64())
+		rawdb.WriteHeadBlockHash(db, block.Hash())
+		rawdb.WriteReceipts(db, block.Hash(), block.NumberU64(), receipts[i])
+	}
+	return &testBackend{db: db}
+}
+
+// TestRangeLimit verifies that a non-zero rangeLimit rejects range queries whose
+// resolved span (end - begin) exceeds the cap, that the "latest" sentinel is
+// resolved before the comparison, and that a zero cap disables the check. This
+// mirrors upstream go-ethereum's --rpc.rangelimit behaviour.
+func TestRangeLimit(t *testing.T) {
+	t.Parallel()
+
+	const head = 20
+	backend := newBackendWithChain(t, head)
+
+	assertExceeds := func(t *testing.T, begin, end int64, limit uint64, want bool) {
+		t.Helper()
+		filter := NewRangeFilter(backend, begin, end, nil, nil, limit)
+		_, err := filter.Logs(context.Background())
+		got := err != nil && strings.Contains(err.Error(), "exceed maximum block range")
+		if got != want {
+			t.Fatalf("begin=%d end=%d limit=%d: range-limit error = %v (err=%v), want %v", begin, end, limit, got, err, want)
+		}
+	}
+
+	// Span 0..20 (= 20) with cap 5 must be rejected.
+	assertExceeds(t, 0, head, 5, true)
+	// The "latest" sentinel (-1) must resolve to head before the comparison,
+	// so 0..latest with cap 5 is rejected just the same.
+	assertExceeds(t, 0, -1, 5, true)
+	// A span within the cap is accepted.
+	assertExceeds(t, 0, 5, 5, false)
+	// A zero cap disables the check entirely, even for the full range.
+	assertExceeds(t, 0, -1, 0, false)
 }

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1168,6 +1168,7 @@ func (p *Pending) EstimateGas(ctx context.Context, args struct {
 type Resolver struct {
 	backend       ethapi.Backend
 	logQueryLimit int
+	rangeLimit    uint64
 }
 
 func (r *Resolver) Block(ctx context.Context, args struct {
@@ -1322,7 +1323,7 @@ func (r *Resolver) Logs(ctx context.Context, args struct{ Filter FilterCriteria 
 		return nil, err
 	}
 	// Construct the range filter
-	filter := filters.NewRangeFilter(filters.Backend(r.backend), begin, end, addresses, topics)
+	filter := filters.NewRangeFilter(filters.Backend(r.backend), begin, end, addresses, topics, r.rangeLimit)
 	return runFilter(ctx, r.backend, filter)
 }
 

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -50,7 +50,7 @@ func TestBuildSchema(t *testing.T) {
 	}
 	defer stack.Close()
 	// Make sure the schema can be parsed and matched up to the object model.
-	if err := newHandler(stack, nil, []string{}, []string{}, 0); err != nil {
+	if err := newHandler(stack, nil, []string{}, []string{}, 0, 0); err != nil {
 		t.Errorf("Could not construct GraphQL handler: %v", err)
 	}
 }
@@ -263,7 +263,7 @@ func createGQLService(t *testing.T, stack *node.Node) {
 		t.Fatalf("could not create import blocks: %v", err)
 	}
 	// create gql service
-	err = New(stack, ethBackend.APIBackend, []string{}, []string{}, 0)
+	err = New(stack, ethBackend.APIBackend, []string{}, []string{}, 0, 0)
 	if err != nil {
 		t.Fatalf("could not create graphql service: %v", err)
 	}
@@ -348,7 +348,7 @@ func createGQLServiceWithTransactions(t *testing.T, stack *node.Node) {
 		t.Fatalf("could not create import blocks: %v", err)
 	}
 	// create gql service
-	err = New(stack, ethBackend.APIBackend, []string{}, []string{}, 0)
+	err = New(stack, ethBackend.APIBackend, []string{}, []string{}, 0, 0)
 	if err != nil {
 		t.Fatalf("could not create graphql service: %v", err)
 	}

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -57,19 +57,20 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // New constructs a new GraphQL service instance.
 //
 // logQueryLimit caps the number of addresses and per-position topics accepted
-// by the `logs` resolvers. 0 disables the cap.
-func New(stack *node.Node, backend ethapi.Backend, cors, vhosts []string, logQueryLimit int) error {
+// by the `logs` resolvers. rangeLimit caps the block range accepted by the
+// top-level `logs` resolver. 0 disables either cap.
+func New(stack *node.Node, backend ethapi.Backend, cors, vhosts []string, logQueryLimit int, rangeLimit uint64) error {
 	if backend == nil {
 		panic("missing backend")
 	}
 	// check if http server with given endpoint exists and enable graphQL on it
-	return newHandler(stack, backend, cors, vhosts, logQueryLimit)
+	return newHandler(stack, backend, cors, vhosts, logQueryLimit, rangeLimit)
 }
 
 // newHandler returns a new `http.Handler` that will answer GraphQL queries.
 // It additionally exports an interactive query browser on the / endpoint.
-func newHandler(stack *node.Node, backend ethapi.Backend, cors, vhosts []string, logQueryLimit int) error {
-	q := Resolver{backend: backend, logQueryLimit: logQueryLimit}
+func newHandler(stack *node.Node, backend ethapi.Backend, cors, vhosts []string, logQueryLimit int, rangeLimit uint64) error {
+	q := Resolver{backend: backend, logQueryLimit: logQueryLimit, rangeLimit: rangeLimit}
 
 	s, err := graphql.ParseSchema(schema, &q)
 	if err != nil {

--- a/les/client.go
+++ b/les/client.go
@@ -298,7 +298,7 @@ func (s *LightEthereum) APIs() []rpc.API {
 		}, {
 			Namespace: "eth",
 			Version:   "1.0",
-			Service:   filters.NewPublicFilterAPI(s.ApiBackend, true, 5*time.Minute, s.config.RPCLogQueryLimit),
+			Service:   filters.NewPublicFilterAPI(s.ApiBackend, true, 5*time.Minute, s.config.RPCLogQueryLimit, s.config.RangeLimit),
 			Public:    true,
 		}, {
 			Namespace: "net",


### PR DESCRIPTION
RangeLimit knob: a configurable cap on the (toBlock - fromBlock) span accepted by eth_getLogs, eth_getFilterLogs, and the GraphQL logs resolvers, wired to a new --rpc.rangelimit flag. Default is 0 (disabled).