### PR TITLE
crypto/secp256k1: reject non-canonical points in IsOnCurve

### DIFF
--- a/crypto/secp256k1/curve.go
+++ b/crypto/secp256k1/curve.go
@@ -92,6 +92,13 @@ func (BitCurve *BitCurve) Params() *elliptic.CurveParams {
 
 // IsOnCurve returns true if the given (x,y) lies on the BitCurve.
 func (BitCurve *BitCurve) IsOnCurve(x, y *big.Int) bool {
+	// Reject non-canonical coordinates (>= P). The reductions below would
+	// otherwise accept e.g. x = x' + P, which later panics in libsecp256k1
+	// when the point is re-encoded.
+	if x.Cmp(BitCurve.P) >= 0 || y.Cmp(BitCurve.P) >= 0 {
+		return false
+	}
+
 	// y² = x³ + b
 	y2 := new(big.Int).Mul(y, y) //y²
 	y2.Mod(y2, BitCurve.P)       //y²%P

--- a/p2p/discover/v4wire/v4wire_test.go
+++ b/p2p/discover/v4wire/v4wire_test.go
@@ -18,6 +18,7 @@ package v4wire
 
 import (
 	"encoding/hex"
+	"math/big"
 	"net"
 	"reflect"
 	"testing"
@@ -129,4 +130,33 @@ func hexPubkey(h string) (ret Pubkey) {
 	}
 	copy(ret[:], b)
 	return ret
+}
+
+// TestDecodePubkeyNonCanonical ensures that public keys with coordinates that
+// are not in canonical form (>= the curve prime P) are rejected. Such a point
+// can pass a naive mod-P on-curve check but later panics in libsecp256k1 when
+// re-encoded, allowing a remote peer to crash the node via a Neighbors packet.
+func TestDecodePubkeyNonCanonical(t *testing.T) {
+	curve := crypto.S256()
+	p := curve.Params().P
+
+	// Build a valid point for x = 1, then offset x by P so it stays the same
+	// value mod P but is no longer canonical.
+	x := big.NewInt(1)
+	rhs := new(big.Int).Mul(x, x)
+	rhs.Mul(rhs, x)
+	rhs.Add(rhs, curve.Params().B)
+	rhs.Mod(rhs, p)
+	y := new(big.Int).ModSqrt(rhs, p)
+	if y == nil {
+		t.Fatal("no valid y for x=1 on secp256k1")
+	}
+
+	var e Pubkey
+	new(big.Int).Add(x, p).FillBytes(e[:len(e)/2]) // x + P, non-canonical
+	y.FillBytes(e[len(e)/2:])
+
+	if _, err := DecodePubkey(curve, e); err != ErrBadPoint {
+		t.Fatalf("non-canonical pubkey accepted, got err = %v, want ErrBadPoint", err)
+	}
 }


### PR DESCRIPTION
A discv4 peer could send a Neighbors packet with a pubkey whose X or Y coordinate is >= the curve prime P (e.g. X = 1 + P). The mod-P reductions in IsOnCurve accepted it, but re-encoding the point in libsecp256k1 returns 0 and panics, crashing the node. Reject coordinates >= P up front.