### PR TITLE
Fix waiver txpool fee check

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"math/big"
 	"sort"
@@ -717,6 +718,13 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 			return errBadPriorityKey
 		}
 		isGasWaiver = transactor.IsGasPriceWaiver
+		// Mirror the execution-layer rule (validatePriorityGasFields): a waiver
+		// sender must submit zero fee fields. Without this the pool accepts a
+		// waiver tx with non-zero fees that execution always rejects, leaving it
+		// stuck in the pool forever.
+		if isGasWaiver && !tx.HasZeroFee() {
+			return fmt.Errorf("%w: waiver priority tx must have zero fee fields", errNoGasPriceWaiver)
+		}
 		// Assure transaction meets fee requirements for non gas waiver transactors
 		if !isGasWaiver {
 			// keep the original rule: if they don't have waiver, they can't submit a zero-fee tx

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -258,6 +258,38 @@ func TestWaiverPriorityTxBypassesBaseFee(t *testing.T) {
 	}
 }
 
+// Test that a waiver priority tx with non-zero fee fields is rejected at pool
+// admission with errNoGasPriceWaiver, matching the execution-layer rule in
+// validatePriorityGasFields. Without this the pool would accept a tx that
+// execution always rejects, leaving it stuck in the pool forever.
+func TestWaiverPriorityTxNonZeroFeeRejected(t *testing.T) {
+	t.Parallel()
+
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+	blockchain := &testBlockChain{10000000, statedb, new(event.Feed), WaiverPriorityTx, common.PriorityTransactorMap{}}
+
+	key, _ := crypto.GenerateKey()
+	pool := NewTxPool(testTxPoolConfig, eip1559Config, blockchain)
+	defer pool.Stop()
+	<-pool.initDoneCh
+
+	from := crypto.PubkeyToAddress(key.PublicKey)
+	testAddBalance(pool, from, new(big.Int).Mul(big.NewInt(10), big.NewInt(params.Ether)))
+
+	// A non-zero feeCap with zero tip should be rejected.
+	tx := priorityTx(0, 21_000, big.NewInt(1_000_000_000), big.NewInt(0), key, priorityPrivateKeys[0])
+	if err := pool.AddRemote(tx); !errors.Is(err, errNoGasPriceWaiver) {
+		t.Fatalf("expected %v, got %v", errNoGasPriceWaiver, err)
+	}
+
+	// A non-zero tip (with feeCap >= tip so the tip-above-feeCap guard passes)
+	// should also be rejected.
+	tx = priorityTx(0, 21_000, big.NewInt(2), big.NewInt(1), key, priorityPrivateKeys[0])
+	if err := pool.AddRemote(tx); !errors.Is(err, errNoGasPriceWaiver) {
+		t.Fatalf("expected %v, got %v", errNoGasPriceWaiver, err)
+	}
+}
+
 // Test that a non-waiver priority tx with zero fees is rejected with
 // errNoGasPriceWaiver (the original rule), even before the base fee
 // comparison is reached.

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -588,9 +588,9 @@ func TestStateChangeDuringPriorityTransactionPoolReset(t *testing.T) {
 
 	// setup pool with 2 transaction in it
 	statedb.SetBalance(address, new(big.Int).SetUint64(params.Ether))
-	blockchain := &testChain{&testBlockChain{1000000000, statedb, new(event.Feed), WaiverPriorityTx, common.PriorityTransactorMap{}}, address, &trigger}
+	blockchain := &testChain{&testBlockChain{1000000000, statedb, new(event.Feed), NonWaiverPriorityTx, common.PriorityTransactorMap{}}, address, &trigger}
 
-	tx0 := priorityTx(0, 100000, big.NewInt(0), big.NewInt(0), key, priorityPrivateKeys[0])
+	tx0 := priorityTx(0, 100000, big.NewInt(100000), big.NewInt(100000), key, priorityPrivateKeys[0])
 	tx1 := priorityTx(1, 100000, big.NewInt(100000), big.NewInt(100000), key, priorityPrivateKeys[0])
 
 	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
@@ -995,13 +995,13 @@ func TestPriorityTransactionDoubleNonce(t *testing.T) {
 		statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
 		statedb.AddBalance(addr, big.NewInt(100000000000000))
 
-		pool.chain = &testBlockChain{1000000, statedb, new(event.Feed), WaiverPriorityTx, common.PriorityTransactorMap{}}
+		pool.chain = &testBlockChain{1000000, statedb, new(event.Feed), NonWaiverPriorityTx, common.PriorityTransactorMap{}}
 		<-pool.requestReset(nil, nil)
 	}
 	resetState()
 
 	signer := types.LatestSignerForChainID(big.NewInt(1))
-	tx1 := priorityTx(0, 21000, big.NewInt(0), big.NewInt(0), key, priorityPrivateKeys[0])
+	tx1 := priorityTx(0, 21000, big.NewInt(5), big.NewInt(5), key, priorityPrivateKeys[0])
 	tx2 := priorityTx(0, 21000, big.NewInt(10), big.NewInt(10), key, priorityPrivateKeys[0])
 	tx3 := priorityTx(0, 21000, big.NewInt(20), big.NewInt(20), key, priorityPrivateKeys[0])
 	tx4 := priorityTx(0, 21000, big.NewInt(10), big.NewInt(10), key, priorityPrivateKeys[0])


### PR DESCRIPTION
A gas-price-waiver priority sender could submit a transaction with non-zero fee fields that the txpool accepted but execution always rejected, leaving it stuck in the pool forever — because validateTx skipped fee checks for waiver senders while execution required their fees to be zero.