### PR TITLE
consensus/istanbul: reject non-empty ProposerSeal in pre-fork verifyS…

### DIFF
--- a/consensus/istanbul/engine/engine.go
+++ b/consensus/istanbul/engine/engine.go
@@ -300,6 +300,22 @@ func (e *Engine) verifySigner(chain consensus.ChainHeaderReader, header *types.H
 	// Pre-fork: Coinbase is not cryptographically bound to the proposer.
 	// Proposer authenticity is enforced at the consensus message layer
 	// (handlePreprepareMsg). Here we can only verify validator-set membership.
+	//
+	// Reject any non-empty ProposerSeal pre-fork. Honest nodes never write a
+	// ProposerSeal before FutureFork (Seal() gates it on IsFutureFork), so a
+	// present seal can only come from a Byzantine proposer. Without this check
+	// the field is silently accepted here but later fails in Author(), which
+	// unconditionally recovers from any 65-byte ProposerSeal — an inconsistent
+	// validation path that lets a poisoned proposal be finalized and then
+	// breaks snapshot construction over that header.
+	extra, err := types.ExtractQBFTExtra(header)
+	if err != nil {
+		return err
+	}
+	if len(extra.ProposerSeal) != 0 {
+		return istanbulcommon.ErrInvalidSignature
+	}
+
 	if _, v := validators.GetByAddress(header.Coinbase); v == nil {
 		return istanbulcommon.ErrUnauthorized
 	}

--- a/consensus/istanbul/engine/engine_test.go
+++ b/consensus/istanbul/engine/engine_test.go
@@ -900,3 +900,51 @@ func TestPreFork_AuthorReturnsCoinbase(t *testing.T) {
 		t.Fatalf("Author() mismatch: have %s, want %s", author.Hex(), addr.Hex())
 	}
 }
+
+// TestPreFork_VerifySignerRejectsProposerSeal is a regression test for a
+// consensus-liveness bug: pre-fork, verifySigner used to only check Coinbase
+// validator-set membership and silently ignore ProposerSeal, while Author()
+// unconditionally recovers from any 65-byte ProposerSeal. A Byzantine proposer
+// could therefore poison a pre-fork proposal with a malformed seal that passed
+// verification but later broke snapshot construction in Author(). verifySigner
+// must now reject any non-empty ProposerSeal pre-fork.
+func TestPreFork_VerifySignerRejectsProposerSeal(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	valSet := validator.NewSet([]common.Address{addr}, istanbul.NewProposerPolicy(istanbul.RoundRobin))
+
+	engine := NewEngine(&istanbul.Config{}, addr, func(data []byte) ([]byte, error) {
+		return crypto.Sign(crypto.Keccak256(data), key)
+	})
+	chain := newForkAwareChain(preForkConfig())
+
+	header := &types.Header{
+		Number:     big.NewInt(1),
+		MixDigest:  types.IstanbulDigest,
+		Difficulty: istanbulcommon.DefaultDifficulty,
+		Coinbase:   addr,
+		UncleHash:  types.EmptyUncleHash,
+		Time:       2,
+		GasLimit:   30_000_000,
+	}
+	if err := ApplyHeaderQBFTExtra(header, WriteValidators([]common.Address{addr})); err != nil {
+		t.Fatalf("apply extra: %v", err)
+	}
+
+	// A clean pre-fork header (no ProposerSeal) must still be accepted.
+	if err := engine.verifySigner(chain, header, nil, valSet); err != nil {
+		t.Fatalf("verifySigner rejected clean pre-fork header: %v", err)
+	}
+
+	// Poison it with a malformed 65-byte ProposerSeal.
+	if err := ApplyHeaderQBFTExtra(header, writeProposerSeal(bytes.Repeat([]byte{0xff}, types.IstanbulExtraSeal))); err != nil {
+		t.Fatalf("write proposer seal: %v", err)
+	}
+
+	if err := engine.verifySigner(chain, header, nil, valSet); err != istanbulcommon.ErrInvalidSignature {
+		t.Fatalf("verifySigner should reject pre-fork ProposerSeal with %v, got %v", istanbulcommon.ErrInvalidSignature, err)
+	}
+}


### PR DESCRIPTION
…igner

Pre-fork, verifySigner only checked Coinbase validator-set membership and ignored ProposerSeal, while Author() unconditionally recovers from any 65-byte ProposerSeal. A Byzantine proposer could poison a pre-fork proposal with a malformed seal that passed verification but later broke snapshot construction in Author(), stalling honest nodes. Reject any non-empty ProposerSeal pre-fork; honest nodes never write one (Seal gates it on IsFutureFork).